### PR TITLE
Sync up develop (Changed deploydoc URL to GenX.jl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center"> <img src="docs/src/assets/logo_readme.svg"  height ="200"width="1000" alt="GenX.jl"></img></div>
 
 [![CI](https://github.com/GenXProject/GenX/actions/workflows/ci.yml/badge.svg)](https://github.com/GenXProject/GenX/actions/workflows/ci.yml)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://genxproject.github.io/GenX/dev)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://genxproject.github.io/GenX.jl/dev)
 [![DOI](https://zenodo.org/badge/10814088.svg)](https://zenodo.org/badge/latestdoi/10814088)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -110,7 +110,7 @@ makedocs(;
     sitename="GenX",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://genxproject.github.io/GenX/stable",
+        canonical="https://genxproject.github.io/GenX.jl/stable",
         assets = ["assets/genx_style.css"],
         sidebar_sitename=false,
         collapselevel=1
@@ -122,7 +122,7 @@ makedocs(;
 # ===========================
 
 deploydocs(;
-    repo="github.com/GenXProject/GenX.git",
+    repo="github.com/GenXProject/GenX.jl.git",
     target = "build",
     branch = "gh-pages",
     devbranch = "main",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -107,7 +107,7 @@ pages = OrderedDict(
 makedocs(;
     modules=[GenX],
     authors="Jesse Jenkins, Nestor Sepulveda, Dharik Mallapragada, Aaron Schwartz, Neha Patankar, Qingyu Xu, Jack Morris, Sambuddha Chakrabarti",
-    sitename="GenX",
+    sitename="GenX.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://genxproject.github.io/GenX.jl/stable",


### PR DESCRIPTION
Pull up develop to sync with main and release branch (Changed the URL to GenX.jl for doc rendering)