### PR TITLE
Discount cUnmetPolicyPenalty in write_multi_stage_cost.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix write_status with UCommit = WriteShadowPrices = 1 (#645)
 - Fixed outputting capital recovery cost to 0 if the remaining number of years is 0 (#666)
 - Updated the docstring for the initialize_cost_to_go function and adjusted the formula for the discount factor to reflect the code implementation (#672).
+- Fix write_multi_stage_cost.jl: add discount with OPEX multipliers to cUnmetPolicyPenalty (#679)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/src/multi_stage/write_multi_stage_costs.jl
+++ b/src/multi_stage/write_multi_stage_costs.jl
@@ -36,7 +36,7 @@ function write_multi_stage_costs(outpath::String, settings_d::Dict, inputs_dict:
     end
 
     # For OPEX costs, apply additional discounting
-    for cost in ["cVar", "cNSE", "cStart", "cUnmetRsv"]
+    for cost in ["cVar", "cNSE", "cStart", "cUnmetRsv", "cUnmetPolicyPenalty"]
         if cost in df_costs[!, :Costs]
             df_costs[df_costs[!, :Costs] .== cost, 2:end] = transpose(OPEXMULTS) .*
                                                             df_costs[df_costs[!, :Costs] .== cost,


### PR DESCRIPTION
## Description
Add discount with OPEX multipliers  to `cUnmetPolicyPenalty` in [write_multi_stage_cost.jl](https://github.com/GenXProject/GenX.jl/blob/5100d174b17357cd054a4234dcfeeaeadea58e1a/src/multi_stage/write_multi_stage_costs.jl#L40).
This should fix #623.
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Related Tickets & Documents
#623 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
Tested on the multistage example. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
