### PR TITLE
Add can_retire validation for multi-stage optimization

### DIFF
--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -159,6 +159,9 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
         model_dict[t] = generate_model(mysetup, inputs_dict[t], OPTIMIZER)
     end
 
+    # check that resources do not switch from can_retire = 0 to can_retire = 1 between stages
+    validate_can_retire_multistage(inputs_dict, mysetup["MultiStageSettingsDict"]["NumStages"])
+
     ### Solve model
     println("Solving Model")
 

--- a/src/model/utility.jl
+++ b/src/model/utility.jl
@@ -80,3 +80,37 @@ function by_rid_res(rid::Integer, sym::Symbol, rs::Vector{<:AbstractResource})
     f = isdefined(GenX, sym) ? getfield(GenX, sym) : x -> getproperty(x, sym)
     return f(r)
 end
+
+@doc raw"""
+    (inputs_dict::Dict, num_stages::Int)
+
+This function validates that all the resources do not switch from havig `can_retire = 0` to `can_retire = 1` during the multi-stage optimization.
+
+# Arguments
+- `inputs_dict::Dict`: A dictionary containing the inputs for each stage.
+- `num_stages::Int`: The number of stages in the multi-stage optimization.
+
+# Returns
+- Throws an error if a resource switches from `can_retire = 0` to `can_retire = 1` between stages.
+"""
+function validate_can_retire_multistage(inputs_dict::Dict, num_stages::Int)
+    for stage in 2:num_stages   # note: loop starts from 2 because we are comparing stage t with stage t-1
+        can_retire_current = can_retire.(inputs_dict[stage]["RESOURCES"])
+        can_retire_previous = can_retire.(inputs_dict[stage - 1]["RESOURCES"])
+
+        # Check if any resource switched from can_retire = 0 to can_retire = 1 between stage t-1 and t
+        if any(can_retire_current .- can_retire_previous .> 0)
+            # Find the resources that switched from can_retire = 0 to can_retire = 1 and throw an error
+            retire_switch_ids = findall(can_retire_current .- can_retire_previous .> 0)
+            resources_switched = inputs_dict[stage]["RESOURCES"][retire_switch_ids]
+            for resource in resources_switched
+                @warn "Resource `$(resource_name(resource))` with id = $(resource_id(resource)) switched " *
+                      "from can_retire = 0 to can_retire = 1 between stages $(stage - 1) and $stage"
+            end
+            msg = "Current implementation of multi-stage optimization does not allow resources " *
+                  "to switch from can_retire = 0 to can_retire = 1 between stages."
+            error(msg)
+        end
+    end
+    return nothing
+end

--- a/test/test_multistage.jl
+++ b/test/test_multistage.jl
@@ -185,4 +185,74 @@ end
 
 test_update_cumulative_min_ret!()
 
+function test_can_retire_validation()
+    @testset "No resources switch from can_retire = 0 to can_retire = 1" begin
+        inputs = Dict{Int,Dict}()
+        inputs[1] = Dict("RESOURCES" => [
+            GenX.Thermal(Dict(:resource => "thermal", :id => 1,
+                :can_retire => 1)),
+            GenX.Vre(Dict(:resource => "vre", :id => 2,
+                :can_retire => 1)),
+            GenX.Hydro(Dict(:resource => "hydro", :id => 3,
+                :can_retire => 1)),
+            GenX.FlexDemand(Dict(:resource => "flex_demand", :id => 4,
+                :can_retire => 1))])
+        inputs[2] = Dict("RESOURCES" => [
+            GenX.Thermal(Dict(:resource => "thermal", :id => 1,
+                :can_retire => 0)),
+            GenX.Vre(Dict(:resource => "vre", :id => 2,
+                :can_retire => 1)),
+            GenX.Hydro(Dict(:resource => "hydro", :id => 3,
+                :can_retire => 1)),
+            GenX.FlexDemand(Dict(:resource => "flex_demand", :id => 4,
+                :can_retire => 1))])
+        inputs[3] = Dict("RESOURCES" => [
+            GenX.Thermal(Dict(:resource => "thermal", :id => 1,
+                :can_retire => 0)),
+            GenX.Vre(Dict(:resource => "vre", :id => 2,
+                :can_retire => 0)),
+            GenX.Hydro(Dict(:resource => "hydro", :id => 3,
+                :can_retire => 1)),
+            GenX.FlexDemand(Dict(:resource => "flex_demand", :id => 4,
+                :can_retire => 1))])
+        @test isnothing(GenX.validate_can_retire_multistage(inputs, 3))
+    end
+
+    @testset "One resource switches from can_retire = 0 to can_retire = 1" begin
+        inputs = Dict{Int,Dict}()
+        inputs[1] = Dict("RESOURCES" => [
+            GenX.Thermal(Dict(:resource => "thermal", :id => 1,
+                :can_retire => 0)),
+            GenX.Vre(Dict(:resource => "vre", :id => 2,
+                :can_retire => 0)),
+            GenX.Hydro(Dict(:resource => "hydro", :id => 3,
+                :can_retire => 0)),
+            GenX.FlexDemand(Dict(:resource => "flex_demand", :id => 4,
+                :can_retire => 1))])
+        inputs[2] = Dict("RESOURCES" => [
+            GenX.Thermal(Dict(:resource => "thermal", :id => 1,
+                :can_retire => 0)),
+            GenX.Vre(Dict(:resource => "vre", :id => 2,
+                :can_retire => 0)),
+            GenX.Hydro(Dict(:resource => "hydro", :id => 3,
+                :can_retire => 1)),
+            GenX.FlexDemand(Dict(:resource => "flex_demand", :id => 4,
+                :can_retire => 1))])
+        inputs[3] = Dict("RESOURCES" => [
+            GenX.Thermal(Dict(:resource => "thermal", :id => 1,
+                :can_retire => 0)),
+            GenX.Vre(Dict(:resource => "vre", :id => 2,
+                :can_retire => 0)),
+            GenX.Hydro(Dict(:resource => "hydro", :id => 3,
+                :can_retire => 1)),
+            GenX.FlexDemand(Dict(:resource => "flex_demand", :id => 4,
+                :can_retire => 1))])
+        @test_throws ErrorException GenX.validate_can_retire_multistage(inputs, 3)
+    end
+end
+
+with_logger(ConsoleLogger(stderr, Logging.Error)) do
+    test_can_retire_validation()
+end
+
 end # module TestMultiStage


### PR DESCRIPTION
## Description

The current implementation of multi-stage optimization doesn't allow a resource to switch from `can_retire = 0` to `can_retire = 1` between stages. This PR adds a validation check on the `can_retire` flag and throws an error if necessary. 

## What type of PR is this? (check all applicable)

- [X] Feature

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [ ] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

By running the multi-stage example with `can_retire = 0` for some resources in `stage = 1`, and then switching to `can_retire = 1` in  `stage = 2`. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [ ] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [ ] Remember to squash and merge if incorporating into develop
