### PR TITLE
Fix docstring in operational_reserves.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does not allow a resource to switch from can_retire = 0 to can_retire = 1 between stages. (#683)
 - Add tutorials for running GenX (#637 and #685)
 - Add writing of multistage stats during optimization with foresight (#687)
+- Fix docstring in operational_reserves.jl (#690)
 
 ### Fixed
 - Set MUST_RUN=1 for RealSystemExample/small_hydro plants (#517).

--- a/src/model/core/operational_reserves.jl
+++ b/src/model/core/operational_reserves.jl
@@ -46,9 +46,9 @@ where $\epsilon^{contingency}$ is static contingency requirement in MWs.
 Option 2 (dynamic capacity-based contingency) is expressed by the following constraints:
 ```math
 \begin{aligned}
-	&Contingency \geq \Omega^{size}_{y,z} \times \alpha^{Contingency,Aux}_{y,z} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
-	&\alpha^{Contingency,Aux}_{y,z} \leq \Delta^{\text{total}}_{y,z} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
-	&\alpha^{Contingency,Aux}_{y,z} \geq M_y \times \Delta^{\text{total}}_{y,z} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
+	& Contingency \geq \Omega^{size}_{y,z} \times \alpha^{Contingency,Aux}_{y,z} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
+	& \alpha^{Contingency,Aux}_{y,z} \leq \Delta^{\text{total}}_{y,z} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
+	& \Delta^{\text{total}}_{y,z} \leq M_y \times \alpha^{Contingency,Aux}_{y,z} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
 \end{aligned}
 ```
 
@@ -60,7 +60,7 @@ Option 3 (dynamic commitment-based contingency) is expressed by the following se
 \begin{aligned}
 	& Contingency \geq \Omega^{size}_{y,z} \times Contingency\_Aux_{y,z,t} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
 	& Contingency\_Aux_{y,z,t} \leq \nu_{y,z,t} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
-	& Contingency\_Aux_{y,z,t} \geq M_y \times \nu_{y,z,t} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
+    & \nu_{y,z,t} \leq M_y \times Contingency\_Aux_{y,z,t} & \forall y \in \mathcal{UC}, z \in \mathcal{Z}\\
 \end{aligned}
 ```
 


### PR DESCRIPTION
## Description

This PR fixes the docstring of [operational_reserves_contingency!](https://github.com/GenXProject/GenX.jl/blob/5100d174b17357cd054a4234dcfeeaeadea58e1a/src/model/core/operational_reserves.jl#L23-L69) function in `operational_reserves.jl`.
Addresses #689

## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Related Tickets & Documents
Issue #689.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
