### PR TITLE
658 save resource buildout every few optimizer iterations and allow optimizer warm start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Print GenX version at startup and export it to disk (#712)
 - Added the option to output results with time series reconstructed for the entire year (#700)
 - Added default settings in multitage optimization (#703)
+- Added the option to write results after each iteration of a multistage run (Myopic) (#704)
 
 ## [0.4.0] - 2024-03-18
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.8"
+version = "0.4.0-dev.9"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/User_Guide/multi_stage_input.md
+++ b/docs/src/User_Guide/multi_stage_input.md
@@ -120,6 +120,7 @@ A separate settings.yml file includes a list of parameters to be specified to fo
 | Myopic               | 0 = perfect foresight, 1 = myopic model (see above table)                                                                                                          |
 | ConvergenceTolerance | The relative optimality gap used for convergence of the dual dynamic programming algorithm. Only required when Myopic = 0                                          |
 | WACC                 | Rate used to discount non-technology-specific costs from stage to stage (i.e., the “social discount rate”).                                                        |
+| WriteIntermittentOutputs | (valid if Myopic = 1) 0 = do not write intermittent outputs, 1 = write intermittent output. |
 
 |                       |                                                                                  **time\_domain\_reduction\_settings.yml**                                                                                  |
 |:-----------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
+++ b/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
@@ -3,4 +3,4 @@ StageLengths: [10,10,10] # Length of each model stage (years)
 WACC: 0.045 # Weighted average cost of capital
 ConvergenceTolerance: 0.01 # Relative optimality gap used for convergence
 Myopic: 0 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming
-WriteIntermittentOutputs: 1
+

--- a/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
+++ b/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
@@ -2,5 +2,5 @@ NumStages: 3 # Number of model investment planning stages
 StageLengths: [10,10,10] # Length of each model stage (years)
 WACC: 0.045 # Weighted average cost of capital
 ConvergenceTolerance: 0.01 # Relative optimality gap used for convergence
-Myopic: 0 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming
-
+Myopic: 1 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming
+WriteIntermittentOutputs: 0

--- a/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
+++ b/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
@@ -3,4 +3,4 @@ StageLengths: [10,10,10] # Length of each model stage (years)
 WACC: 0.045 # Weighted average cost of capital
 ConvergenceTolerance: 0.01 # Relative optimality gap used for convergence
 Myopic: 1 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming
-WriteIntermittentOutputs: 0
+WriteIntermittentOutputs: 0 # If 1, write intermediate outputs to disk

--- a/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
+++ b/example_systems/6_three_zones_w_multistage/settings/multi_stage_settings.yml
@@ -3,3 +3,4 @@ StageLengths: [10,10,10] # Length of each model stage (years)
 WACC: 0.045 # Weighted average cost of capital
 ConvergenceTolerance: 0.01 # Relative optimality gap used for convergence
 Myopic: 0 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming
+WriteIntermittentOutputs: 1

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -187,7 +187,7 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
     model_dict, mystats_d, inputs_dict = run_ddp(outpath, model_dict, mysetup, inputs_dict)
 
     # Step 4) Write final outputs from each stage
-    if mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"] == 0
+    if mysetup["MultiStageSettingsDict"]["Myopic"] == 0 || mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"] == 0
         for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
             mysetup["MultiStageSettingsDict"]["CurStage"] = p
             outpath_cur = joinpath(outpath, "results_p$p")

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -187,7 +187,8 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
     model_dict, mystats_d, inputs_dict = run_ddp(outpath, model_dict, mysetup, inputs_dict)
 
     # Step 4) Write final outputs from each stage
-    if mysetup["MultiStageSettingsDict"]["Myopic"] == 0 || mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"] == 0
+    if mysetup["MultiStageSettingsDict"]["Myopic"] == 0 ||
+       mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"] == 0
         for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
             mysetup["MultiStageSettingsDict"]["CurStage"] = p
             outpath_cur = joinpath(outpath, "results_p$p")

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -109,8 +109,6 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
     multistage_settings = get_settings_path(case, "multi_stage_settings.yml") # Multi stage settings YAML file path
     # merge default settings with those specified in the YAML file
     mysetup["MultiStageSettingsDict"] = configure_settings_multistage(multistage_settings)
-    println(mysetup["MultiStageSettingsDict"])
-    println(mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"])
 
     ### Cluster time series inputs if necessary and if specified by the user
     if mysetup["TimeDomainReduction"] == 1

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -109,6 +109,9 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
     multistage_settings = get_settings_path(case, "multi_stage_settings.yml") # Multi stage settings YAML file path
     # merge default settings with those specified in the YAML file
     mysetup["MultiStageSettingsDict"] = configure_settings_multistage(multistage_settings)
+    println(mysetup["MultiStageSettingsDict"])
+    println(mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"])
+
     ### Cluster time series inputs if necessary and if specified by the user
     if mysetup["TimeDomainReduction"] == 1
         tdr_settings = get_settings_path(case, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
@@ -186,10 +189,12 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
     model_dict, mystats_d, inputs_dict = run_ddp(outpath, model_dict, mysetup, inputs_dict)
 
     # Step 4) Write final outputs from each stage
-    for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
-        mysetup["MultiStageSettingsDict"]["CurStage"] = p
-        outpath_cur = joinpath(outpath, "results_p$p")
-        write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
+    if mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"] == 0
+        for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+            mysetup["MultiStageSettingsDict"]["CurStage"] = p
+            outpath_cur = joinpath(outpath, "results_p$p")
+            write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
+        end
     end
 
     # Step 5) Write DDP summary outputs

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -207,8 +207,8 @@ function validate_multistage_settings!(settings::Dict{Any, Any})
     # If we find any then make a response and issue a note to the user.
 
     if settings["Myopic"] == 0 && settings["WriteIntermittentOutputs"] == 1
-        msg = "WriteIntermittentOutputs is not supported for non-myopic multistage models." * 
-        " Setting WriteIntermittentOutputs to 0 in the multistage settings."
+        msg = "WriteIntermittentOutputs is not supported for non-myopic multistage models." *
+              " Setting WriteIntermittentOutputs to 0 in the multistage settings."
         @warn msg
         settings["WriteIntermittentOutputs"] = 0
     end

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -174,7 +174,8 @@ function default_settings_multistage()
         "StageLengths" => [10, 10, 10],
         "WACC" => 0.045,
         "ConvergenceTolerance" => 0.01,
-        "Myopic" => 1)
+        "Myopic" => 1, 
+        "WriteIntermittentOutputs" => 0)
 end
 
 @doc raw"""
@@ -197,5 +198,18 @@ function configure_settings_multistage(settings_path::String)
     settings = default_settings_multistage()
     merge!(settings, model_settings)
 
+    validate_multistage_settings!(settings)
     return settings
+end
+
+function validate_multistage_settings!(settings::Dict{Any, Any})
+    # Check for any settings combinations that are not allowed.
+    # If we find any then make a response and issue a note to the user.
+
+    if settings["Myopic"] == 0 && settings["WriteIntermittentOutputs"] == 1
+        msg = "WriteIntermittentOutputs is not supported for non-myopic multistage models." * 
+        " Setting WriteIntermittentOutputs to 0 in the multistage settings."
+        @warn msg
+        settings["WriteIntermittentOutputs"] = 0
+    end
 end

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -174,7 +174,7 @@ function default_settings_multistage()
         "StageLengths" => [10, 10, 10],
         "WACC" => 0.045,
         "ConvergenceTolerance" => 0.01,
-        "Myopic" => 1, 
+        "Myopic" => 1,
         "WriteIntermittentOutputs" => 0)
 end
 

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -200,6 +200,14 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
             t = 1 #  update forward pass solution for the first stage
             models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
             inputs_d[t]["solve_time"] = solve_time_d[t]
+
+            if myopic && WriteIntermittentOutputs
+                for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+                    outpath_cur = joinpath(outpath, "results_p$p")
+                    write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
+                end
+            end
+            
         end
         ## Forward pass for t=2:num_stages
         for t in 2:num_stages
@@ -222,6 +230,13 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
             # Step d.iii) Solve the model at time t
             models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
             inputs_d[t]["solve_time"] = solve_time_d[t]
+
+            if myopic && WriteIntermittentOutputs
+                for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+                    outpath_cur = joinpath(outpath, "results_p$p")
+                    write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
+                end
+            end
         end
 
         ### For the myopic solution, algorithm should terminate here after the first forward pass calculation and then move to Outputs writing.

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -171,13 +171,11 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
     models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
     inputs_d[t]["solve_time"] = solve_time_d[t]
 
-    if myopic && write_intermittent_outputs
-        for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
-            outpath_cur = joinpath(outpath, "results_p$p")
-            write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
-        end
+    if myopic && write_intermittent_outputs 
+        outpath_cur = joinpath(outpath, "results_p$t")
+        write_outputs(models_d[t], outpath_cur, setup, inputs_d[t])
     end
-    
+
     # Step c.i) Initialize the lower bound, equal to the objective function value for the first period in the first iteration
     global z_lower = objective_value(models_d[t])
 
@@ -231,11 +229,9 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
             models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
             inputs_d[t]["solve_time"] = solve_time_d[t]
 
-            if myopic && write_intermittent_outputs
-                for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
-                    outpath_cur = joinpath(outpath, "results_p$p")
-                    write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
-                end
+            if myopic && write_intermittent_outputs 
+                outpath_cur = joinpath(outpath, "results_p$t")
+                write_outputs(models_d[t], outpath_cur, setup, inputs_d[t])
             end
         end
 

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -229,7 +229,7 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
             models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
             inputs_d[t]["solve_time"] = solve_time_d[t]
 
-            if myopic && write_intermittent_outputs 
+            if myopic && write_intermittent_outputs
                 outpath_cur = joinpath(outpath, "results_p$t")
                 write_outputs(models_d[t], outpath_cur, setup, inputs_d[t])
             end

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -201,7 +201,7 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
             models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
             inputs_d[t]["solve_time"] = solve_time_d[t]
 
-            if myopic && WriteIntermittentOutputs
+            if myopic && mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"]
                 for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
                     outpath_cur = joinpath(outpath, "results_p$p")
                     write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])
@@ -231,7 +231,7 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
             models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
             inputs_d[t]["solve_time"] = solve_time_d[t]
 
-            if myopic && WriteIntermittentOutputs
+            if myopic && mysetup["MultiStageSettingsDict"]["WriteIntermittentOutputs"]
                 for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
                     outpath_cur = joinpath(outpath, "results_p$p")
                     write_outputs(model_dict[p], outpath_cur, mysetup, inputs_dict[p])

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -171,7 +171,7 @@ function run_ddp(outpath::AbstractString, models_d::Dict, setup::Dict, inputs_d:
     models_d[t], solve_time_d[t] = solve_model(models_d[t], setup)
     inputs_d[t]["solve_time"] = solve_time_d[t]
 
-    if myopic && write_intermittent_outputs 
+    if myopic && write_intermittent_outputs
         outpath_cur = joinpath(outpath, "results_p$t")
         write_outputs(models_d[t], outpath_cur, setup, inputs_d[t])
     end

--- a/test/test_multistage.jl
+++ b/test/test_multistage.jl
@@ -12,7 +12,8 @@ multistage_setup = Dict("NumStages" => 3,
     "StageLengths" => [10, 10, 10],
     "WACC" => 0.045,
     "ConvergenceTolerance" => 0.01,
-    "Myopic" => 0)
+    "Myopic" => 0,
+    "WriteIntermittentOutputs" => 0)
 
 genx_setup = Dict("Trans_Loss_Segments" => 1,
     "OperationalReserves" => 1,


### PR DESCRIPTION
## Description

This PR adds in an additional step in run_ddp where the outputs are saved after each iteration of a multistage run. It does so through the use of a new key in multistage settings called WriteIntermittentOutputs, and uses the function write_outputs().

This PR changes the files dual_dynamic_programming.jl (run_ddp()) and case_runner.jl (run_genx_multistage). It merges into the branch configure_multistage_settings because it needs the default key for WriteIntermittentOutputs in configure_multistage_settings.

## What type of PR is this? (check all applicable)

- [X] Feature
## Related Tickets & Documents

Issue #658 

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [X] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [X] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

This can be tested by adding a key in multistage_settings.yml in example 6 to WriteIntermittentOutputs: 1, then running example 6 as usual and observing that all outputs are occurring as expected after each iteration of the run. Testing was done to ensure that everything is working correctly.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
