### PR TITLE
Allow dev docs to track develop branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documenter
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ['*']
 
 jobs:
@@ -13,7 +13,9 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix formatting and images in tutorials 3, 5, 6, and 8 to address issue #697 (#698)
-- Fix `devbranch` in the docs `make.jl` file to track the develop branch 
+- Fix `devbranch` in the docs `make.jl` file to track the develop branch (#710)
 
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix formatting and images in tutorials 3, 5, 6, and 8 to address issue #697 (#698)
+- Fix `devbranch` in the docs `make.jl` file to track the develop branch 
 
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -124,7 +124,7 @@ deploydocs(;
     repo = "github.com/GenXProject/GenX.jl.git",
     target = "build",
     branch = "gh-pages",
-    devbranch = "main",
+    devbranch = "develop",
     devurl = "dev",
     push_preview = true,
     versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],


### PR DESCRIPTION
## Description

This PR updates the `devbranch` in the `make.jl` file of the docs to track the develop branch instead of the main branch.

## What type of PR is this? (check all applicable)

- [x] Feature

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
