### PR TITLE
Add workflow to check PR, update existing workflows

### DIFF
--- a/.github/workflows/PR_checks.yml
+++ b/.github/workflows/PR_checks.yml
@@ -1,0 +1,42 @@
+name: PR Check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces update of changelog file on every pull request
+  Changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabels: 'Skip-Changelog'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          missingUpdateErrorMessage: >
+            No update to CHANGELOG.md found! Please add an entry describing 
+            your change and include the pull request tag. Note that we use 
+            the keepachangelog format (https://keepachangelog.com). If your 
+            change doesn’t require a changelog entry, please add the 
+            'Skip-Changelog' label to the pull request.
+
+  # Check if the version number in the Project.toml file is updated
+  Version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check version number
+        if: github.event.pull_request.base.ref == 'develop'
+        shell: bash {0}
+        run: |
+          git fetch origin develop &> /dev/null
+          vdiff=$(git diff -U0 origin/develop -- Project.toml | grep -E "^\+" | grep "version =")
+          if [ -z "$vdiff" ];
+          then
+            echo "::error::Error: version number in Project.toml has not been updated." && exit 1
+
+          else
+            echo "Version number in Project.toml has been updated."
+            echo "New" ${vdiff:1}
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
           - x64
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
-      - uses: julia-actions/cache@v1.2.2
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
       - name: Test examples
         shell: julia --project=. --color=yes {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)
+- Add workflow that ensures that CHANGELOG.md and the version number are updated (#711)
 
 ## [0.4.0] - 2024-03-18
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.2"
+version = "0.4.0-dev.4"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
## Description

This PR adds a new GitHub workflow/action to remind the author to update the CHANGELOG.md file and version number when a PR targeting develop is opened. If the 'Skip-Changelog' label is added to the PR, the first check will be skipped.

## What type of PR is this? (check all applicable)

- [x] Feature

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
