### PR TITLE
Print version at startup and export it to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)
 - Add workflow that ensures that CHANGELOG.md and the version number are updated (#711)
+- Print GenX version at startup and export it to disk (#712) 
 
 ## [0.4.0] - 2024-03-18
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.4"
+version = "0.4.0-dev.5"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/GenX.jl
+++ b/src/GenX.jl
@@ -62,6 +62,7 @@ function include_all_in_folder(folder)
     end
 end
 
+include("startup/genx_startup.jl")
 include_all_in_folder("case_runners")
 include_all_in_folder("configure_settings")
 include_all_in_folder("configure_solver")

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -29,6 +29,7 @@ run_genx_case!("path/to/case", Gurobi.Optimizer)
 ```
 """
 function run_genx_case!(case::AbstractString, optimizer::Any = HiGHS.Optimizer)
+    print_genx_version()
     genx_settings = get_settings_path(case, "genx_settings.yml") # Settings YAML file path
     writeoutput_settings = get_settings_path(case, "output_settings.yml") # Write-output settings YAML file path
     mysetup = configure_settings(genx_settings, writeoutput_settings) # mysetup dictionary stores settings and GenX-specific parameters

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -29,7 +29,6 @@ run_genx_case!("path/to/case", Gurobi.Optimizer)
 ```
 """
 function run_genx_case!(case::AbstractString, optimizer::Any = HiGHS.Optimizer)
-    print_genx_version()
     genx_settings = get_settings_path(case, "genx_settings.yml") # Settings YAML file path
     writeoutput_settings = get_settings_path(case, "output_settings.yml") # Write-output settings YAML file path
     mysetup = configure_settings(genx_settings, writeoutput_settings) # mysetup dictionary stores settings and GenX-specific parameters

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -50,7 +50,7 @@ settings dictionary.
 - `settings::Dict`: The settings dictionary.
 """
 function configure_settings(settings_path::String, output_settings_path::String)
-    println("Configuring Settings")
+    println("\nConfiguring Settings")
     model_settings = YAML.load(open(settings_path))
 
     settings = default_settings()

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -4,7 +4,8 @@ end
 
 function print_genx_version()
     v = pkgversion(GenX)
-    ascii_art = raw"""  ____           __  __   _ _
+    ascii_art = raw"""
+     ____           __  __   _ _
     / ___| ___ _ __ \ \/ /  (_) |
    | |  _ / _ \ '_ \ \  /   | | |
    | |_| |  __/ | | |/  \ _ | | |

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -16,7 +16,6 @@ function print_genx_version()
     return nothing
 end
 
-
 # This function is a workaround for Julia versions < 1.9.
 function pkgversion(m::Module)
     if VERSION >= v"1.9"

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -2,7 +2,6 @@ function __init__()
     print_genx_version()
 end
 
-
 function print_genx_version()
     v = pkgversion(GenX)
     ascii_art = raw"""  ____           __  __   _ _

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -1,3 +1,7 @@
+function __init__()
+    print_genx_version()
+end
+
 function print_genx_version()
     v = pkgversion(GenX)
     ascii_art = raw"""  ____           __  __   _ _
@@ -7,7 +11,7 @@ function print_genx_version()
     \____|\___|_| |_/_/\_(_)/ |_|
                           |__/
     """
-    ascii_art *= "Version: $(v)\n"
+    ascii_art *= "Version: $(v)"
     println(ascii_art)
     return nothing
 end

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -1,0 +1,13 @@
+function print_genx_version()
+    v = pkgversion(GenX)
+    ascii_art = raw"""  ____           __  __   _ _
+    / ___| ___ _ __ \ \/ /  (_) |
+   | |  _ / _ \ '_ \ \  /   | | |
+   | |_| |  __/ | | |/  \ _ | | |
+    \____|\___|_| |_/_/\_(_)/ |_|
+                          |__/
+    """
+    ascii_art *= "Version: $(v)\n"
+    println(ascii_art)
+    return nothing
+end

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -2,6 +2,7 @@ function __init__()
     print_genx_version()
 end
 
+
 function print_genx_version()
     v = pkgversion(GenX)
     ascii_art = raw"""  ____           __  __   _ _
@@ -14,4 +15,25 @@ function print_genx_version()
     ascii_art *= "Version: $(v)"
     println(ascii_art)
     return nothing
+end
+
+
+# This function is a workaround for Julia versions < 1.9.
+function pkgversion(m::Module)
+    if VERSION >= v"1.9"
+        return Base.pkgversion(m)
+    else
+        _pkgdir = pkgdir(m)
+        _pkgdir === nothing && return nothing
+        project_file = joinpath(_pkgdir, "Project.toml")
+        isa(project_file, String) && return get_project_version(project_file)
+        return nothing
+    end
+end
+
+function get_project_version(project_file::String)
+    d = Base.parsed_toml(project_file)
+    v = get(d, "version", nothing)
+    isnothing(v) && return nothing
+    return VersionNumber(v::AbstractString)
 end

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -533,7 +533,6 @@ Writes a file named `env_summary.yml` in the specified directory.
 """
 function write_system_env_summary(path::AbstractString)
     v = pkgversion(GenX)
-    
     env_summary = Dict(
         :ARCH => getproperty(Sys, :ARCH),
         :CPU_NAME => getproperty(Sys, :CPU_NAME),

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -43,6 +43,7 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
     # Dict containing the list of outputs to write
     output_settings_d = setup["WriteOutputsSettingsDict"]
     write_settings_file(path, setup)
+    write_system_env_summary(path)
 
     output_settings_d["WriteStatus"] && write_status(path, inputs, setup, EP)
 
@@ -513,4 +514,37 @@ Internal function for writing settings files
 """
 function write_settings_file(path, setup)
     YAML.write_file(joinpath(path, "run_settings.yml"), setup)
+end
+
+"""
+    write_system_env_summary(path::AbstractString)
+
+Write a summary of the current testing environment to a YAML file. The summary 
+includes information like the CPU name and architecture, number of CPU threads, 
+JIT status, operating system kernel, machine name, Julia standard library path, 
+Julia version and GenX version.
+
+# Arguments
+- `path::AbstractString`: The directory path where the YAML file will be written.
+
+# Output
+Writes a file named `env_summary.yml` in the specified directory.
+
+"""
+function write_system_env_summary(path::AbstractString)
+    v = pkgversion(GenX)
+    
+    env_summary = Dict(
+        :ARCH => getproperty(Sys, :ARCH),
+        :CPU_NAME => getproperty(Sys, :CPU_NAME),
+        :CPU_THREADS => getproperty(Sys, :CPU_THREADS),
+        :JIT => getproperty(Sys, :JIT),
+        :KERNEL => getproperty(Sys, :KERNEL),
+        :MACHINE => getproperty(Sys, :MACHINE),
+        :JULIA_STDLIB => getproperty(Sys, :STDLIB),
+        :JULIA_VERSION => VERSION,
+        :GENX_VERSION => v
+    )
+
+    YAML.write_file(joinpath(path, "system_summary.yml"), env_summary)
 end


### PR DESCRIPTION
## Description

This PR adds two new functions to the codebase:
- `print_genx_version()` that prints the version of GenX to the console when loading GenX. 
- `write_system_env_summary()` that writes a summary of the current testing environment to a YAML file. 

This information can be helpful for reproducing and analyzing test results.

## What type of PR is this? (check all applicable)

- [X] Feature

## Related Tickets & Documents
It addresses issue #708.

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [X] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [X] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [X] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

By running the example cases. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
