### PR TITLE
Make None colum in Fuels_data optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix formatting and images in tutorials 3, 5, 6, and 8 to address issue #697 (#698)
 - Fix `devbranch` in the docs `make.jl` file to track the develop branch (#710)
+- Fix `TDR` to load `Fuels_data.csv` w/wo optional `None` column (#720)
 
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.9"
+version = "0.4.0-dev.10"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -1339,6 +1339,7 @@ function cluster_inputs(inpath,
                     "inputs_p$per",
                     mysetup["SystemFolder"],
                     "Fuels_data.csv"))
+                ensure_column!(fuel_in, "None", 0.0)
                 select!(fuel_in, Not(:Time_Index))
                 SepFirstRow = DataFrame(fuel_in[1, :])
                 NewFuelOutput = vcat(SepFirstRow, FPOutputData)
@@ -1484,6 +1485,7 @@ function cluster_inputs(inpath,
                 input_stage_directory,
                 mysetup["SystemFolder"],
                 "Fuels_data.csv"))
+            ensure_column!(fuel_in, "None", 0.0)
             select!(fuel_in, Not(:Time_Index))
             SepFirstRow = DataFrame(fuel_in[1, :])
             NewFuelOutput = vcat(SepFirstRow, FPOutputData)
@@ -1599,6 +1601,7 @@ function cluster_inputs(inpath,
         ### TDR_Results/Fuels_data.csv
         system_path = joinpath(inpath, mysetup["SystemFolder"])
         fuel_in = load_dataframe(joinpath(system_path, "Fuels_data.csv"))
+        ensure_column!(fuel_in, "None", 0.0)
         select!(fuel_in, Not(:Time_Index))
         SepFirstRow = DataFrame(fuel_in[1, :])
         NewFuelOutput = vcat(SepFirstRow, FPOutputData)


### PR DESCRIPTION
## Description

Fix TDR to load `Fuels_data.csv` even without a `None` column. 

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Related Tickets & Documents
Addresses #552 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [X] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

By running any example case with `TimeDomainReduction: 1` and without a `None` column in the `Fuels_data.csv` input file.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
