### PR TITLE
Remove bogus Hydro_* columns in examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.14"
+version = "0.4.0-dev.15"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/example_systems/2_three_zones_w_electrolyzer/resources/Thermal.csv
+++ b/example_systems/2_three_zones_w_electrolyzer/resources/Thermal.csv
@@ -1,4 +1,4 @@
-Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Hydro_Energy_to_Power_Ratio,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
-MA_natural_gas_combined_cycle,1,1,1,0,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0,0.468,0.25,0.5,0,0,MA,1
-CT_natural_gas_combined_cycle,2,1,1,0,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0,0.338,0.133332722,0.266665444,0,0,CT,1
-ME_natural_gas_combined_cycle,3,1,1,0,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0,0.474,0.033333333,0.066666667,0,0,ME,1
+Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
+MA_natural_gas_combined_cycle,1,1,1,0,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0.468,0.25,0.5,0,0,MA,1
+CT_natural_gas_combined_cycle,2,1,1,0,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0.338,0.133332722,0.266665444,0,0,CT,1
+ME_natural_gas_combined_cycle,3,1,1,0,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0.474,0.033333333,0.066666667,0,0,ME,1

--- a/example_systems/6_three_zones_w_multistage/inputs/inputs_p1/resources/Thermal.csv
+++ b/example_systems/6_three_zones_w_multistage/inputs/inputs_p1/resources/Thermal.csv
@@ -1,4 +1,4 @@
-Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Hydro_Energy_to_Power_Ratio,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
-MA_natural_gas_combined_cycle,1,1,1,1,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0,0.468,0.25,0.5,0,0,MA,1
-CT_natural_gas_combined_cycle,2,1,1,1,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0,0.338,0.133332722,0.266665444,0,0,CT,1
-ME_natural_gas_combined_cycle,3,1,1,1,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0,0.474,0.033333333,0.066666667,0,0,ME,1
+Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
+MA_natural_gas_combined_cycle,1,1,1,1,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0.468,0.25,0.5,0,0,MA,1
+CT_natural_gas_combined_cycle,2,1,1,1,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0.338,0.133332722,0.266665444,0,0,CT,1
+ME_natural_gas_combined_cycle,3,1,1,1,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0.474,0.033333333,0.066666667,0,0,ME,1

--- a/example_systems/6_three_zones_w_multistage/inputs/inputs_p2/resources/Thermal.csv
+++ b/example_systems/6_three_zones_w_multistage/inputs/inputs_p2/resources/Thermal.csv
@@ -1,4 +1,4 @@
-Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Hydro_Energy_to_Power_Ratio,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
-MA_natural_gas_combined_cycle,1,1,1,1,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0,0.468,0.25,0.5,0,0,MA,1
-CT_natural_gas_combined_cycle,2,1,1,1,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0,0.338,0.133332722,0.266665444,0,0,CT,1
-ME_natural_gas_combined_cycle,3,1,1,1,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0,0.474,0.033333333,0.066666667,0,0,ME,1
+Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
+MA_natural_gas_combined_cycle,1,1,1,1,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0.468,0.25,0.5,0,0,MA,1
+CT_natural_gas_combined_cycle,2,1,1,1,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0.338,0.133332722,0.266665444,0,0,CT,1
+ME_natural_gas_combined_cycle,3,1,1,1,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0.474,0.033333333,0.066666667,0,0,ME,1

--- a/example_systems/6_three_zones_w_multistage/inputs/inputs_p3/resources/Thermal.csv
+++ b/example_systems/6_three_zones_w_multistage/inputs/inputs_p3/resources/Thermal.csv
@@ -1,4 +1,4 @@
-Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Hydro_Energy_to_Power_Ratio,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
-MA_natural_gas_combined_cycle,1,1,1,1,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0,0.468,0.25,0.5,0,0,MA,1
-CT_natural_gas_combined_cycle,2,1,1,1,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0,0.338,0.133332722,0.266665444,0,0,CT,1
-ME_natural_gas_combined_cycle,3,1,1,1,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0,0.474,0.033333333,0.066666667,0,0,ME,1
+Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Max_Cap_MW,Min_Cap_MW,Inv_Cost_per_MWyr,Fixed_OM_Cost_per_MWyr,Var_OM_Cost_per_MWh,Heat_Rate_MMBTU_per_MWh,Fuel,Cap_Size,Start_Cost_per_MW,Start_Fuel_MMBTU_per_MW,Up_Time,Down_Time,Ramp_Up_Percentage,Ramp_Dn_Percentage,Min_Power,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
+MA_natural_gas_combined_cycle,1,1,1,1,0,-1,0,65400,10287,3.55,7.43,MA_NG,250,91,2,6,6,0.64,0.64,0.468,0.25,0.5,0,0,MA,1
+CT_natural_gas_combined_cycle,2,1,1,1,0,-1,0,65400,9698,3.57,7.12,CT_NG,250,91,2,6,6,0.64,0.64,0.338,0.133332722,0.266665444,0,0,CT,1
+ME_natural_gas_combined_cycle,3,1,1,1,0,-1,0,65400,16291,4.5,12.62,ME_NG,250,91,2,6,6,0.64,0.64,0.474,0.033333333,0.066666667,0,0,ME,1


### PR DESCRIPTION
## Description
Remove `Hydro_Energy_to_Power_Ratio` column from `thermal.csv` files in two example_systems.

## What type of PR is this? (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Code Refactor
- [ ] Performance Improvements

## Related Tickets & Documents
Fixes #737

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
n/a

## Post-approval checklist for GenX core developers
After the PR is approved

- [ ] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [ ] Remember to squash and merge if incorporating into develop
