### PR TITLE
Fix default value of cap size api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `load_vre_stor_variability!` to load only wind or solar resources as 
 part of the VRE_STOR module (#728)
 - Fix typo in HydrogenMinimumProduction setting key (#746)
-- Fix default value of `Cap_Size` attribute for thermal generators
+- Fix default value of `Cap_Size` attribute for thermal generators (#747)
 
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `load_vre_stor_variability!` to load only wind or solar resources as 
 part of the VRE_STOR module (#728)
 - Fix typo in HydrogenMinimumProduction setting key (#746)
+- Fix default value of `Cap_Size` attribute for thermal generators
 
 ### Added
 - Add objective scaler for addressing problem ill-conditioning (#667)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.18"
+version = "0.4.0-dev.19"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/model/resources/resources.jl
+++ b/src/model/resources/resources.jl
@@ -580,7 +580,7 @@ existing_cap_mw(r::AbstractResource) = r.existing_cap_mw
 existing_cap_mwh(r::AbstractResource) = get(r, :existing_cap_mwh, default_zero)
 existing_charge_cap_mw(r::AbstractResource) = get(r, :existing_charge_cap_mw, default_zero)
 
-cap_size(r::AbstractResource) = get(r, :cap_size, default_zero)
+cap_size(r::AbstractResource) = get(r, :cap_size, 1)
 
 num_vre_bins(r::AbstractResource) = get(r, :num_vre_bins, default_zero)
 


### PR DESCRIPTION
## Description

This PR fixes the default value of the `cap_size` function in the resource interface.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
