### PR TITLE
Feature/update h2demand name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.0-dev.24"
+version = "0.4.0-dev.25"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/User_Guide/model_input.md
+++ b/docs/src/User_Guide/model_input.md
@@ -787,4 +787,4 @@ This file contains inputs specifying regional hydrogen production requirements. 
 |H2DemandConstraint| Index of the hydrogen demand constraint.|
 |Constraint\_Description| Names of hydrogen demand constraints; not to be read by model, but used as a helpful notation to the model user. |
 |Hydrogen\_Demand\_kt| Hydrogen production requirements in 1,000 tons|
-|PriceH2| Price of hydrogen per metric ton ($/t)|
+|PriceCap| Price of hydrogen per metric ton ($/t)|

--- a/example_systems/2_three_zones_w_electrolyzer/policies/Hydrogen_demand.csv
+++ b/example_systems/2_three_zones_w_electrolyzer/policies/Hydrogen_demand.csv
@@ -1,2 +1,2 @@
-﻿H2DemandConstraint,ConstraintDescription,Hydrogen_Demand_kt,PriceH2
+﻿H2DemandConstraint,ConstraintDescription,Hydrogen_Demand_kt,PriceCap
 1,all,6000,9999

--- a/example_systems/8_three_zones_w_colocated_VRE_storage_electrolyzers/policies/Hydrogen_demand.csv
+++ b/example_systems/8_three_zones_w_colocated_VRE_storage_electrolyzers/policies/Hydrogen_demand.csv
@@ -1,2 +1,2 @@
-﻿H2DemandConstraint,ConstraintDescription,Hydrogen_Demand_kt,PriceH2
+﻿H2DemandConstraint,ConstraintDescription,Hydrogen_Demand_kt,PriceCap
 1,all,6000,9999

--- a/src/load_inputs/load_hydrogen_demand.jl
+++ b/src/load_inputs/load_hydrogen_demand.jl
@@ -12,8 +12,8 @@ function load_hydrogen_demand!(setup::Dict, path::AbstractString, inputs::Dict)
 
     scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1 # Million $/kton if scaled, $/ton if not scaled
 
-    if "PriceH2" in names(df)
-        inputs["H2DemandPriceH2"] = df[!, :PriceH2] / scale_factor
+    if "PriceCap" in names(df)
+        inputs["H2DemandPriceCap"] = df[!, :PriceCap] / scale_factor
     end
     println(filename * " Successfully Read!")
 end

--- a/src/model/policies/hydrogen_demand.jl
+++ b/src/model/policies/hydrogen_demand.jl
@@ -26,13 +26,13 @@ function hydrogen_demand!(EP::Model, inputs::Dict, setup::Dict)
     NumberOfH2DemandReqs = inputs["NumberOfH2DemandReqs"]
 
     ## Zonal level limit constraint
-    if haskey(inputs, "H2DemandPriceH2")
+    if haskey(inputs, "H2DemandPriceCap")
         @variable(EP, vH2Demand_slack[h2demand = 1:NumberOfH2DemandReqs]>=0)
         add_similar_to_expression!(EP[:eH2DemandRes], vH2Demand_slack)
 
         @expression(EP,
             eCH2Demand_slack[h2demand = 1:NumberOfH2DemandReqs],
-            inputs["H2DemandPriceH2"][h2demand]*EP[:vH2Demand_slack][h2demand])
+            inputs["H2DemandPriceCap"][h2demand]*EP[:vH2Demand_slack][h2demand])
         @expression(EP,
             eTotalCH2DemandSlack,
             sum(EP[:eCH2Demand_slack][h2demand] for h2demand in 1:NumberOfH2DemandReqs))

--- a/src/write_outputs/write_costs.jl
+++ b/src/write_outputs/write_costs.jl
@@ -127,7 +127,7 @@ function write_costs(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
         dfCost[9, 2] += value(EP[:eTotalCMinCapSlack])
     end
 
-    if haskey(inputs, "H2DemandPriceH2")
+    if haskey(inputs, "H2DemandPriceCap")
         dfCost[9, 2] += value(EP[:eTotalCH2DemandSlack])
     end
 

--- a/test/electrolyzer/policies/Hydrogen_demand.csv
+++ b/test/electrolyzer/policies/Hydrogen_demand.csv
@@ -1,2 +1,2 @@
-﻿H2DemandConstraint,ConstraintDescription,Hydrogen_Demand_kt,PriceH2
+﻿H2DemandConstraint,ConstraintDescription,Hydrogen_Demand_kt,PriceCap
 1,all,6000,9999


### PR DESCRIPTION
## Description

This PR updates the column name `PriceH2` in `Hydrogen_demand.csv` to `PriceCap` to match the other slack constraints. 
It also makes it easier to distinguish from the `Hydrogen_Price_Per_Tonne` parameter in the electrolyzer input file.

## What type of PR is this? (check all applicable)

- [x] Code Refactor

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [ ] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

With the example case `example_systems/2_three_zones_w_electrolyzer`.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
