### PR TITLE
Fix pr 760

### DIFF
--- a/src/write_outputs/write_charge.jl
+++ b/src/write_outputs/write_charge.jl
@@ -8,6 +8,7 @@ function write_charge(path::AbstractString, inputs::Dict, setup::Dict, EP::Model
     resources = inputs["RESOURCE_NAMES"]    # Resource names
     zones = zone_id.(gen)
 
+    T = inputs["T"]     # Number of time steps (hours)
     STOR_ALL = inputs["STOR_ALL"]
     FLEX = inputs["FLEX"]
     ELECTROLYZER = inputs["ELECTROLYZER"]
@@ -35,8 +36,8 @@ function write_charge(path::AbstractString, inputs::Dict, setup::Dict, EP::Model
         push!(charge, value.(EP[:vCHARGE_VRE_STOR]))
         push!(charge_ids, VS_STOR)
     end
-    charge = reduce(vcat, charge)
-    charge_ids = reduce(vcat, charge_ids)
+    charge = reduce(vcat, charge, init=zeros(0, T))
+    charge_ids = reduce(vcat, charge_ids, init=Int[])
     
     charge *= scale_factor
     

--- a/src/write_outputs/write_co2.jl
+++ b/src/write_outputs/write_co2.jl
@@ -54,7 +54,7 @@ function write_co2_capture_plant(path::AbstractString, inputs::Dict, setup::Dict
 
         df.AnnualSum .= emissions_captured_plant * weight
 
-        write_temporal_data(df, emissions_capture_plant, path, setup, "captured_emissions_plant")
+        write_temporal_data(df, emissions_captured_plant, path, setup, "captured_emissions_plant")
     end
     return nothing
 end

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -484,7 +484,7 @@ end # END output()
 Internal function for writing annual outputs. 
 """
 function write_annual(fullpath::AbstractString, dfOut::DataFrame)
-    push!(dfOut, ["Total" 0 sum(dfOut[!, :AnnualSum])])
+    push!(dfOut, ["Total" 0 sum(dfOut[!, :AnnualSum], init=0.0)])
     CSV.write(fullpath, dfOut)
     return nothing
 end
@@ -504,8 +504,8 @@ function write_fulltimeseries(fullpath::AbstractString,
                     Symbol("AnnualSum");
                     [Symbol("t$t") for t in 1:T]]
     rename!(dfOut, auxNew_Names)
-    total = DataFrame(["Total" 0 sum(dfOut[!, :AnnualSum]) fill(0.0, (1, T))], auxNew_Names)
-    total[!, 4:(T + 3)] .= sum(dataOut, dims = 1)
+    total = DataFrame(["Total" 0 sum(dfOut[!, :AnnualSum], init=0.0) fill(0.0, (1, T))], auxNew_Names)
+    total[!, 4:(T + 3)] .= sum(dataOut, dims = 1, init = 0.0)
     dfOut = vcat(dfOut, total)
 
     CSV.write(fullpath, dftranspose(dfOut, false), writeheader = false)

--- a/src/write_outputs/write_storage.jl
+++ b/src/write_outputs/write_storage.jl
@@ -32,7 +32,7 @@ function write_storage(path::AbstractString, inputs::Dict, setup::Dict, EP::Mode
     if !isempty(VS_STOR)
         push!(stored, value.(EP[:vS_VRE_STOR]))
     end
-    stored = reduce(vcat, stored)
+    stored = reduce(vcat, stored, init=zeros(0, T))
     stored *= scale_factor
 
     stored_ids = convert(Vector{Int}, vcat(STOR_ALL, HYDRO_RES, FLEX, VS_STOR))


### PR DESCRIPTION
## Description

This PR fixes the use of `reduce` and `sum` for empty sets and a typo. 

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Related Tickets & Documents
Fixes a change that I made on #760 and a typo. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [X] Code has been tested to ensure all functionality works as intended.
- [ ] CHANGELOG.md has been updated (if this is a 'notable' change).
- [X] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

By running `test_examples.jl` inside the `test` folder of GenX. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [ ] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [ ] Remember to squash and merge if incorporating into develop
