### PR TITLE
support reuse of Gurobi environment for multistage models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Fusion plant optional features for thermal plants (#743).
+- Support for reusing the same Gurobi environment for multiple solves when 
+number of concurrent Gurobi uses is limited (#783).
 
 ### Changed
 - The `charge.csv` and `storage.csv` files now include only resources with 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.1-dev.8"
+version = "0.4.1-dev.9"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/User_Guide/model_configuration.md
+++ b/docs/src/User_Guide/model_configuration.md
@@ -125,6 +125,7 @@ The following tables summarize the model settings parameters and their default/p
 
 |**Parameter** | **Description**|
 | :------------ | :-----------|
+|Solver | OPTIONAL name of solver. Default is "HiGHS" effectively. It is necessary to set `Solver: "Gurobi"` when [reusing the same gurobi environment for multiple solves](https://github.com/jump-dev/Gurobi.jl?tab=readme-ov-file#reusing-the-same-gurobi-environment-for-multiple-solves).
 |EnableJuMPStringNames | Flag to enable/disable JuMP string names to improve the performance.|
 ||1 = enable JuMP string names.|
 ||0 = disable JuMP string names.|

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -65,7 +65,8 @@ function run_genx_case_simple!(case::AbstractString, mysetup::Dict, optimizer::A
 
     ### Configure solver
     println("Configuring Solver")
-    OPTIMIZER = configure_solver(settings_path, optimizer)
+    solver_name = lowercase(get(mysetup, "Solver", ""))
+    OPTIMIZER = configure_solver(settings_path, optimizer; solver_name=solver_name)
 
     #### Running a case
 
@@ -137,7 +138,8 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
 
     ### Configure solver
     println("Configuring Solver")
-    OPTIMIZER = configure_solver(settings_path, optimizer)
+    solver_name = lowercase(get(mysetup, "Solver", ""))
+    OPTIMIZER = configure_solver(settings_path, optimizer; solver_name=solver_name)
 
     model_dict = Dict()
     inputs_dict = Dict()

--- a/src/configure_solver/configure_solver.jl
+++ b/src/configure_solver/configure_solver.jl
@@ -19,8 +19,10 @@ Currently supported solvers include: "Gurobi", "CPLEX", "Clp", "Cbc", or "SCIP"
 # Returns
 - `optimizer::MathOptInterface.OptimizerWithAttributes`: the configured optimizer instance.
 """
-function configure_solver(solver_settings_path::String, optimizer::Any)
-    solver_name = infer_solver(optimizer)
+function configure_solver(solver_settings_path::String, optimizer::Any; solver_name::String="")
+    if isempty(solver_name)
+        solver_name = infer_solver(optimizer)
+    end
     path = joinpath(solver_settings_path, solver_name * "_settings.yml")
 
     configure_functions = Dict("highs" => configure_highs,


### PR DESCRIPTION
## Description

This PR allows for the use of the Gurobi.Optimizer with multistage models.

When running a multistage model with a "single use" Gurobi license like:
```julia
using GenX
using Gurobi

run_genx_case!(dirname(@__FILE__), Gurobi.Optimizer)
```
one will get
```julia
ERROR: LoadError: Gurobi Error 10009: Single-use license. Another Gurobi process with pid 12345 running.
```

[The solution](https://github.com/jump-dev/Gurobi.jl?tab=readme-ov-file#reusing-the-same-gurobi-environment-for-multiple-solves) looks like:
```julia
using GenX
using Gurobi

if !(@isdefined GRB_ENV)  # the whole point is to only create GRB_ENV once per Julia session
    const GRB_ENV = Gurobi.Env()
end

run_genx_case!(dirname(@__FILE__), () -> Gurobi.Optimizer(GRB_ENV))
```

## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Documentation Update

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
see examples above

