### PR TITLE
Fix getproperty for `Vector{Resources}` to align with new array interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ number of concurrent Gurobi uses is limited (#783).
 charge and storage variables (#760 and #763).
 - Deduplicated docs on optimized scheduled maintenance for thermal resources (#745).
 
+### Fixed
+- Update `getproperty` function for vectors of resources to ensure compatibility 
+with Julia v1.11 (#785).
+
 ## [0.4.1] - 2024-08-20
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.1-dev.9"
+version = "0.4.1-dev.10"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -29,6 +29,7 @@ run_genx_case!("path/to/case", Gurobi.Optimizer)
 ```
 """
 function run_genx_case!(case::AbstractString, optimizer::Any = HiGHS.Optimizer)
+    print_genx_version() # Log the GenX version
     genx_settings = get_settings_path(case, "genx_settings.yml") # Settings YAML file path
     writeoutput_settings = get_settings_path(case, "output_settings.yml") # Write-output settings YAML file path
     mysetup = configure_settings(genx_settings, writeoutput_settings) # mysetup dictionary stores settings and GenX-specific parameters

--- a/src/load_inputs/load_resources_data.jl
+++ b/src/load_inputs/load_resources_data.jl
@@ -522,7 +522,9 @@ function check_retrofit_id(rs::Vector{T}) where {T <: AbstractResource}
     retrofit_options = ids_retrofit_options(rs)
 
     # check that all retrofit_ids for resources that can retrofit and retrofit options match
-    if Set(rs[units_can_retrofit].retrofit_id) != Set(rs[retrofit_options].retrofit_id)
+    can_retrofit_retro_ids = [r.retrofit_id for r in rs[units_can_retrofit]]  # retrofit cluster ids for units that can retrofit
+    retrofit_option_retro_ids = [r.retrofit_id for r in rs[retrofit_options]]  # retrofit cluster ids for retrofit options
+    if Set(can_retrofit_retro_ids) != Set(retrofit_option_retro_ids)
         msg = string("Retrofit IDs for resources that \"can retrofit\" and \"retrofit options\" do not match.\n" *
                      "All retrofitting units must be associated with a retrofit option.")
         push!(warning_strings, msg)

--- a/src/model/resources/resources.jl
+++ b/src/model/resources/resources.jl
@@ -66,9 +66,7 @@ Allows to set the attribute `sym` of an `AbstractResource` object using dot synt
 - `value`: The value to set for the attribute.
 
 """
-Base.setproperty!(r::AbstractResource, sym::Symbol, value) = setindex!(parent(r),
-    value,
-    sym)
+Base.setproperty!(r::AbstractResource, sym::Symbol, value) = setindex!(parent(r), value, sym)
 
 """
     haskey(r::AbstractResource, sym::Symbol)
@@ -254,8 +252,7 @@ julia> findall(r -> max_cap_mwh(r) != 0, gen.Storage)
  50
 ```
 """
-Base.findall(f::Function, rs::Vector{<:AbstractResource}) = resource_id.(filter(r -> f(r),
-    rs))
+Base.findall(f::Function, rs::Vector{<:AbstractResource}) = resource_id.(filter(r -> f(r), rs))
 
 """
     interface(name, default=default_zero, type=AbstractResource)

--- a/src/model/resources/resources.jl
+++ b/src/model/resources/resources.jl
@@ -106,32 +106,31 @@ end
 """ 
     Base.getproperty(rs::Vector{<:AbstractResource}, sym::Symbol)
 
-Allows to access attributes of a vector of `AbstractResource` objects using dot syntax. If the `sym` is an element of the `resource_types` constant, it returns all resources of that type. Otherwise, it returns the value of the attribute for each resource in the vector.
+Allows to return all resources of a given type of a vector of `AbstractResource` objects using dot syntax.
 
 # Arguments:
 - `rs::Vector{<:AbstractResource}`: The vector of `AbstractResource` objects.
-- `sym::Symbol`: The symbol representing the attribute name or a type from `resource_types`.
+- `sym::Symbol`: The symbol representing the type from `resource_types`.
 
 # Returns:
 - If `sym` is an element of the `resource_types` constant, it returns a vector containing all resources of that type.
-- If `sym` is an attribute name, it returns a vector containing the value of the attribute for each resource.
 
 ## Examples
 ```julia
 julia> vre_gen = gen.Vre;  # gen vector of resources
 julia> typeof(vre_gen)
 Vector{Vre} (alias for Array{Vre, 1})
-julia> vre_gen.zone
+julia> GenX.zone_id.(vre_gen)
 ```
 """
 function Base.getproperty(rs::Vector{<:AbstractResource}, sym::Symbol)
-    # if sym is Type then return a vector resources of that type
+    # if sym is one of the resource types then return a vector resources of that type
     if sym ∈ resource_types
         res_type = eval(sym)
         return Vector{res_type}(rs[isa.(rs, res_type)])
+    else
+        return getfield(rs, sym)
     end
-    # if sym is a field of the resource then return that field for all resources
-    return [getproperty(r, sym) for r in rs]
 end
 
 """
@@ -531,14 +530,14 @@ const default_zero = 0
 
 # INTERFACE FOR ALL RESOURCES
 resource_name(r::AbstractResource) = r.resource
-resource_name(rs::Vector{T}) where {T <: AbstractResource} = rs.resource
+resource_name(rs::Vector{T}) where {T <: AbstractResource} = resource_name.(rs)
 
 resource_id(r::AbstractResource)::Int64 = r.id
 resource_id(rs::Vector{T}) where {T <: AbstractResource} = resource_id.(rs)
 resource_type_mga(r::AbstractResource) = r.resource_type
 
 zone_id(r::AbstractResource) = r.zone
-zone_id(rs::Vector{T}) where {T <: AbstractResource} = rs.zone
+zone_id(rs::Vector{T}) where {T <: AbstractResource} = zone_id.(rs)
 
 # getter for boolean attributes (true or false) with validation
 function new_build(r::AbstractResource)

--- a/src/startup/genx_startup.jl
+++ b/src/startup/genx_startup.jl
@@ -1,7 +1,3 @@
-function __init__()
-    print_genx_version()
-end
-
 function print_genx_version()
     v = pkgversion(GenX)
     ascii_art = raw"""

--- a/src/write_outputs/capacity_reserve_margin/write_reserve_margin_revenue.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_reserve_margin_revenue.jl
@@ -73,29 +73,18 @@ function write_reserve_margin_revenue(path::AbstractString,
             gen_VRE_STOR = gen.VreStorage
             tempresrev[VRE_STOR] = derating_factor.(gen_VRE_STOR, tag = i) .*
                                    ((value.(EP[:vP][VRE_STOR, :])) * weighted_price)
-            tempresrev[VRE_STOR_STOR] .-= derating_factor.(
-                gen_VRE_STOR[(gen_VRE_STOR.stor_dc_discharge .!= 0) .| (gen_VRE_STOR.stor_dc_charge .!= 0) .| (gen_VRE_STOR.stor_ac_discharge .!= 0) .| (gen_VRE_STOR.stor_ac_charge .!= 0)],
-                tag = i) .* (value.(EP[:vCHARGE_VRE_STOR][VRE_STOR_STOR,
-                :]).data * weighted_price)
-            tempresrev[DC_DISCHARGE] .+= derating_factor.(
-                gen_VRE_STOR[(gen_VRE_STOR.stor_dc_discharge .!= 0)],
-                tag = i) .* ((value.(EP[:vCAPRES_DC_DISCHARGE][DC_DISCHARGE,
-                :]).data .*
-                                           etainverter.(gen_VRE_STOR[(gen_VRE_STOR.stor_dc_discharge .!= 0)])) *
-                                          weighted_price)
-            tempresrev[AC_DISCHARGE] .+= derating_factor.(
-                gen_VRE_STOR[(gen_VRE_STOR.stor_ac_discharge .!= 0)],
-                tag = i) .* ((value.(EP[:vCAPRES_AC_DISCHARGE][AC_DISCHARGE,
-                :]).data) * weighted_price)
-            tempresrev[DC_CHARGE] .-= derating_factor.(
-                gen_VRE_STOR[(gen_VRE_STOR.stor_dc_charge .!= 0)],
-                tag = i) .* ((value.(EP[:vCAPRES_DC_CHARGE][DC_CHARGE, :]).data ./
-                                        etainverter.(gen_VRE_STOR[(gen_VRE_STOR.stor_dc_charge .!= 0)])) *
-                                       weighted_price)
-            tempresrev[AC_CHARGE] .-= derating_factor.(
-                gen_VRE_STOR[(gen_VRE_STOR.stor_ac_charge .!= 0)],
-                tag = i) .* ((value.(EP[:vCAPRES_AC_CHARGE][AC_CHARGE, :]).data) *
-                                       weighted_price)
+            tempresrev[VRE_STOR_STOR] .-= derating_factor.(gen[VRE_STOR_STOR], tag = i) .* 
+                                            (value.(EP[:vCHARGE_VRE_STOR][VRE_STOR_STOR, :]).data * weighted_price)
+            tempresrev[DC_DISCHARGE] .+= derating_factor.(gen[DC_DISCHARGE], tag = i) .* 
+                                          ((value.(EP[:vCAPRES_DC_DISCHARGE][DC_DISCHARGE, :]).data .*
+                                           etainverter.(gen[DC_DISCHARGE])) * weighted_price)
+            tempresrev[AC_DISCHARGE] .+= derating_factor.(gen[AC_DISCHARGE], tag = i) .* 
+                                          ((value.(EP[:vCAPRES_AC_DISCHARGE][AC_DISCHARGE, :]).data) * weighted_price)
+            tempresrev[DC_CHARGE] .-= derating_factor.(gen[DC_CHARGE], tag = i) .* 
+                                          ((value.(EP[:vCAPRES_DC_CHARGE][DC_CHARGE, :]).data ./
+                                           etainverter.(gen[DC_CHARGE])) * weighted_price)
+            tempresrev[AC_CHARGE] .-= derating_factor.(gen[AC_CHARGE], tag = i) .* 
+                                          ((value.(EP[:vCAPRES_AC_CHARGE][AC_CHARGE, :]).data) * weighted_price)
         end
         tempresrev *= scale_factor
         annual_sum .+= tempresrev

--- a/src/write_outputs/energy_share_requirement/write_esr_revenue.jl
+++ b/src/write_outputs/energy_share_requirement/write_esr_revenue.jl
@@ -47,39 +47,20 @@ function write_esr_revenue(path::AbstractString,
 
         if !isempty(VRE_STOR)
             if !isempty(SOLAR_ONLY)
-                solar_resources = ((gen_VRE_STOR.wind .== 0) .& (gen_VRE_STOR.solar .!= 0))
-                dfESRRev[SOLAR, esr_col] = (value.(EP[:vP_SOLAR][SOLAR, :]).data
-                                            .*
-                                            etainverter.(gen_VRE_STOR[solar_resources]) *
-                                            weight) .*
-                                           esr_vrestor.(gen_VRE_STOR[solar_resources],
-                    tag = i) * price
+                dfESRRev[SOLAR, esr_col] = (value.(EP[:vP_SOLAR][SOLAR, :]).data .*
+                                            etainverter.(gen[SOLAR]) * weight) .*
+                                            esr_vrestor.(gen[SOLAR], tag = i) * price
             end
             if !isempty(WIND_ONLY)
-                wind_resources = ((gen_VRE_STOR.wind .!= 0) .& (gen_VRE_STOR.solar .== 0))
-                dfESRRev[WIND, esr_col] = (value.(EP[:vP_WIND][WIND, :]).data
-                                           *
-                                           weight) .*
-                                          esr_vrestor.(gen_VRE_STOR[wind_resources],
-                    tag = i) * price
+                dfESRRev[WIND, esr_col] = (value.(EP[:vP_WIND][WIND, :]).data * weight) .*
+                                            esr_vrestor.(gen[WIND], tag = i) * price
             end
             if !isempty(SOLAR_WIND)
-                solar_and_wind_resources = ((gen_VRE_STOR.wind .!= 0) .&
-                                            (gen_VRE_STOR.solar .!= 0))
-                dfESRRev[SOLAR_WIND, esr_col] = (((value.(EP[:vP_WIND][SOLAR_WIND,
-                    :]).data * weight)
-                                                  .*
-                                                  esr_vrestor.(
-                    gen_VRE_STOR[solar_and_wind_resources],
-                    tag = i) * price) +
-                                                 (value.(EP[:vP_SOLAR][SOLAR_WIND, :]).data
-                                                  .*
-                                                  etainverter.(gen_VRE_STOR[solar_and_wind_resources])
-                                                  *
-                                                  weight) .*
-                                                 esr_vrestor.(
-                    gen_VRE_STOR[solar_and_wind_resources],
-                    tag = i) * price)
+                dfESRRev[SOLAR_WIND, esr_col] = (((value.(EP[:vP_WIND][SOLAR_WIND, :]).data * weight) .*
+                                                    esr_vrestor.(gen[SOLAR_WIND], tag = i) * price) +
+                                                    (value.(EP[:vP_SOLAR][SOLAR_WIND, :]).data .*
+                                                    etainverter.(gen[SOLAR_WIND]) * weight) .*
+                                                    esr_vrestor.(gen[SOLAR_WIND], tag = i) * price)
             end
         end
     end

--- a/src/write_outputs/write_curtailment.jl
+++ b/src/write_outputs/write_curtailment.jl
@@ -25,12 +25,11 @@ function write_curtailment(path::AbstractString, inputs::Dict, setup::Dict, EP::
         SOLAR = setdiff(inputs["VS_SOLAR"], inputs["VS_WIND"])
         WIND = setdiff(inputs["VS_WIND"], inputs["VS_SOLAR"])
         SOLAR_WIND = intersect(inputs["VS_SOLAR"], inputs["VS_WIND"])
-        gen_VRE_STOR = gen.VreStorage
         if !isempty(SOLAR)
             curtailment[SOLAR, :] = (value.(EP[:eTotalCap_SOLAR][SOLAR]).data .*
-                                     inputs["pP_Max_Solar"][SOLAR, :] .-
-                                     value.(EP[:vP_SOLAR][SOLAR, :]).data) .*
-                                    etainverter.(gen_VRE_STOR[(gen_VRE_STOR.solar .!= 0)])
+                                    inputs["pP_Max_Solar"][SOLAR, :] .-
+                                    value.(EP[:vP_SOLAR][SOLAR, :]).data) .*
+                                    etainverter.(gen[SOLAR])
         end
         if !isempty(WIND)
             curtailment[WIND, :] = (value.(EP[:eTotalCap_WIND][WIND]).data .*
@@ -41,7 +40,7 @@ function write_curtailment(path::AbstractString, inputs::Dict, setup::Dict, EP::
             curtailment[SOLAR_WIND, :] = ((value.(EP[:eTotalCap_SOLAR])[SOLAR_WIND].data .*
                                            inputs["pP_Max_Solar"][SOLAR_WIND, :] .-
                                            value.(EP[:vP_SOLAR][SOLAR_WIND, :]).data) .*
-                                          etainverter.(gen_VRE_STOR[((gen_VRE_STOR.wind .!= 0) .& (gen_VRE_STOR.solar .!= 0))])
+                                          etainverter.(gen[SOLAR_WIND])
                                           +
                                           (value.(EP[:eTotalCap_WIND][SOLAR_WIND]).data .*
                                            inputs["pP_Max_Wind"][SOLAR_WIND, :] .-

--- a/src/write_outputs/write_subsidy_revenue.jl
+++ b/src/write_outputs/write_subsidy_revenue.jl
@@ -56,10 +56,8 @@ function write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, 
                 HAS_MIN_CAP_STOR = ids_with_policy(gen_VRE_STOR, min_cap_stor, tag = mincap)
                 MIN_CAP_GEN_SOLAR = ids_with_policy(gen_VRE_STOR, min_cap_solar, tag = mincap)
                 MIN_CAP_GEN_WIND = ids_with_policy(gen_VRE_STOR, min_cap_wind, tag = mincap)
-                MIN_CAP_GEN_ASYM_DC_DIS = intersect(inputs["VS_ASYM_DC_DISCHARGE"],
-                    HAS_MIN_CAP_STOR)
-                MIN_CAP_GEN_ASYM_AC_DIS = intersect(inputs["VS_ASYM_AC_DISCHARGE"],
-                    HAS_MIN_CAP_STOR)
+                MIN_CAP_GEN_ASYM_DC_DIS = intersect(inputs["VS_ASYM_DC_DISCHARGE"], HAS_MIN_CAP_STOR)
+                MIN_CAP_GEN_ASYM_AC_DIS = intersect(inputs["VS_ASYM_AC_DISCHARGE"], HAS_MIN_CAP_STOR)
                 MIN_CAP_GEN_SYM_DC = intersect(inputs["VS_SYM_DC"], HAS_MIN_CAP_STOR)
                 MIN_CAP_GEN_SYM_AC = intersect(inputs["VS_SYM_AC"], HAS_MIN_CAP_STOR)
                 if !isempty(MIN_CAP_GEN_SOLAR)
@@ -72,7 +70,6 @@ function write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, 
                                                                           (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_ASYM_DC_DIS)
-                    MIN_CAP_GEN_ASYM_DC_DIS = intersect(inputs["VS_ASYM_DC_DISCHARGE"], HAS_MIN_CAP_STOR)
                     dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_ASYM_DC_DIS] .+= ((value.(EP[:eTotalCapDischarge_DC][MIN_CAP_GEN_ASYM_DC_DIS].data) .* 
                                                                                 etainverter.(gen[MIN_CAP_GEN_ASYM_DC_DIS])) * 
                                                                                 (dual.(EP[:cZoneMinCapReq][mincap])))

--- a/src/write_outputs/write_subsidy_revenue.jl
+++ b/src/write_outputs/write_subsidy_revenue.jl
@@ -54,9 +54,7 @@ function write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, 
             if !isempty(inputs["VRE_STOR"])
                 gen_VRE_STOR = gen.VreStorage
                 HAS_MIN_CAP_STOR = ids_with_policy(gen_VRE_STOR, min_cap_stor, tag = mincap)
-                MIN_CAP_GEN_SOLAR = ids_with_policy(gen_VRE_STOR,
-                    min_cap_solar,
-                    tag = mincap)
+                MIN_CAP_GEN_SOLAR = ids_with_policy(gen_VRE_STOR, min_cap_solar, tag = mincap)
                 MIN_CAP_GEN_WIND = ids_with_policy(gen_VRE_STOR, min_cap_wind, tag = mincap)
                 MIN_CAP_GEN_ASYM_DC_DIS = intersect(inputs["VS_ASYM_DC_DISCHARGE"],
                     HAS_MIN_CAP_STOR)
@@ -85,13 +83,13 @@ function write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, 
                 end
                 if !isempty(MIN_CAP_GEN_SYM_DC)
                     dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SYM_DC] .+= ((value.(EP[:eTotalCap_STOR][MIN_CAP_GEN_SYM_DC]).data .* 
-                                                                            power_to_energy_dc.(gen[intersect(HAS_MIN_CAP_STOR, storage_sym_dc_discharge(gen))]) .* 
-                                                                            etainverter.(gen[intersect(HAS_MIN_CAP_STOR, storage_sym_dc_discharge(gen))])) * 
+                                                                            power_to_energy_dc.(gen[MIN_CAP_GEN_SYM_DC]) .* 
+                                                                            etainverter.(gen[MIN_CAP_GEN_SYM_DC])) * 
                                                                             (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_SYM_AC)
                     dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SYM_AC] .+= ((value.(EP[:eTotalCap_STOR][MIN_CAP_GEN_SYM_AC]).data .* 
-                                                                            power_to_energy_ac.(gen[intersect(HAS_MIN_CAP_STOR, storage_sym_ac_discharge(gen))])) * 
+                                                                            power_to_energy_ac.(gen[MIN_CAP_GEN_SYM_AC])) * 
                                                                             (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
             end

--- a/src/write_outputs/write_subsidy_revenue.jl
+++ b/src/write_outputs/write_subsidy_revenue.jl
@@ -65,48 +65,33 @@ function write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, 
                 MIN_CAP_GEN_SYM_DC = intersect(inputs["VS_SYM_DC"], HAS_MIN_CAP_STOR)
                 MIN_CAP_GEN_SYM_AC = intersect(inputs["VS_SYM_AC"], HAS_MIN_CAP_STOR)
                 if !isempty(MIN_CAP_GEN_SOLAR)
-                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SOLAR] .+= ((value.(EP[:eTotalCap_SOLAR][MIN_CAP_GEN_SOLAR]).data)
-                                                                           .*
-                                                                           etainverter.(gen[ids_with_policy(
-                        gen,
-                        min_cap_solar,
-                        tag = mincap)])
-                                                                           *
-                                                                           (dual.(EP[:cZoneMinCapReq][mincap])))
+                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SOLAR] .+= ((value.(EP[:eTotalCap_SOLAR][MIN_CAP_GEN_SOLAR]).data) .*
+                                                                            etainverter.(gen[MIN_CAP_GEN_SOLAR]) * 
+                                                                            (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_WIND)
-                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_WIND] .+= ((value.(EP[:eTotalCap_WIND][MIN_CAP_GEN_WIND]).data)
-                                                                          *
+                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_WIND] .+= ((value.(EP[:eTotalCap_WIND][MIN_CAP_GEN_WIND]).data) * 
                                                                           (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_ASYM_DC_DIS)
-                    MIN_CAP_GEN_ASYM_DC_DIS = intersect(inputs["VS_ASYM_DC_DISCHARGE"],
-                        HAS_MIN_CAP_STOR)
-                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_ASYM_DC_DIS] .+= ((value.(EP[:eTotalCapDischarge_DC][MIN_CAP_GEN_ASYM_DC_DIS].data)
-                                                                                  .*
-                                                                                  etainverter.(gen_VRE_STOR[min_cap_stor.(gen_VRE_STOR, tag = mincap) .== 1 .& (gen_VRE_STOR.stor_dc_discharge .== 2)]))
-                                                                                 *
-                                                                                 (dual.(EP[:cZoneMinCapReq][mincap])))
+                    MIN_CAP_GEN_ASYM_DC_DIS = intersect(inputs["VS_ASYM_DC_DISCHARGE"], HAS_MIN_CAP_STOR)
+                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_ASYM_DC_DIS] .+= ((value.(EP[:eTotalCapDischarge_DC][MIN_CAP_GEN_ASYM_DC_DIS].data) .* 
+                                                                                etainverter.(gen[MIN_CAP_GEN_ASYM_DC_DIS])) * 
+                                                                                (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_ASYM_AC_DIS)
-                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_ASYM_AC_DIS] .+= ((value.(EP[:eTotalCapDischarge_AC][MIN_CAP_GEN_ASYM_AC_DIS]).data)
-                                                                                 *
-                                                                                 (dual.(EP[:cZoneMinCapReq][mincap])))
+                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_ASYM_AC_DIS] .+= ((value.(EP[:eTotalCapDischarge_AC][MIN_CAP_GEN_ASYM_AC_DIS]).data) * 
+                                                                                (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_SYM_DC)
-                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SYM_DC] .+= ((value.(EP[:eTotalCap_STOR][MIN_CAP_GEN_SYM_DC]).data
-                                                                             .*
-                                                                             power_to_energy_dc.(gen_VRE_STOR[(min_cap_stor.(gen_VRE_STOR, tag = mincap) .== 1 .& (gen_VRE_STOR.stor_dc_discharge .== 1))])
-                                                                             .*
-                                                                             etainverter.(gen_VRE_STOR[(min_cap_stor.(gen_VRE_STOR, tag = mincap) .== 1 .& (gen_VRE_STOR.stor_dc_discharge .== 1))]))
-                                                                            *
+                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SYM_DC] .+= ((value.(EP[:eTotalCap_STOR][MIN_CAP_GEN_SYM_DC]).data .* 
+                                                                            power_to_energy_dc.(gen[intersect(HAS_MIN_CAP_STOR, storage_sym_dc_discharge(gen))]) .* 
+                                                                            etainverter.(gen[intersect(HAS_MIN_CAP_STOR, storage_sym_dc_discharge(gen))])) * 
                                                                             (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
                 if !isempty(MIN_CAP_GEN_SYM_AC)
-                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SYM_AC] .+= ((value.(EP[:eTotalCap_STOR][MIN_CAP_GEN_SYM_AC]).data
-                                                                             .*
-                                                                             power_to_energy_ac.(gen_VRE_STOR[(min_cap_stor.(gen_VRE_STOR, tag = mincap) .== 1 .& (gen_VRE_STOR.stor_ac_discharge .== 1))]))
-                                                                            *
+                    dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN_SYM_AC] .+= ((value.(EP[:eTotalCap_STOR][MIN_CAP_GEN_SYM_AC]).data .* 
+                                                                            power_to_energy_ac.(gen[intersect(HAS_MIN_CAP_STOR, storage_sym_ac_discharge(gen))])) * 
                                                                             (dual.(EP[:cZoneMinCapReq][mincap])))
                 end
             end

--- a/src/write_outputs/write_vre_stor.jl
+++ b/src/write_outputs/write_vre_stor.jl
@@ -354,7 +354,7 @@ function write_vre_stor_charge(path::AbstractString, inputs::Dict, setup::Dict, 
             AnnualSum = Array{Union{Missing, Float32}}(undef, size(DC_CHARGE)[1]))
         charge_dc = zeros(size(DC_CHARGE)[1], T)
         charge_dc = value.(EP[:vP_DC_CHARGE]).data ./
-                    etainverter.(gen_VRE_STOR[(gen_VRE_STOR.stor_dc_discharge .!= 0)]) *
+                    etainverter.(gen[DC_CHARGE]) *
                     (setup["ParameterScale"] == 1 ? ModelScalingFactor : 1)
         dfCharge_DC.AnnualSum .= charge_dc * inputs["omega"]
 
@@ -410,7 +410,7 @@ function write_vre_stor_discharge(path::AbstractString,
             Zone = inputs["ZONES_DC_DISCHARGE"],
             AnnualSum = Array{Union{Missing, Float32}}(undef, size(DC_DISCHARGE)[1]))
         power_vre_stor = value.(EP[:vP_DC_DISCHARGE]).data .*
-                         etainverter.(gen_VRE_STOR[(gen_VRE_STOR.stor_dc_discharge .!= 0)])
+                         etainverter.(gen[DC_DISCHARGE])
         if setup["ParameterScale"] == 1
             power_vre_stor *= ModelScalingFactor
         end
@@ -486,7 +486,7 @@ function write_vre_stor_discharge(path::AbstractString,
             Zone = inputs["ZONES_SOLAR"],
             AnnualSum = Array{Union{Missing, Float32}}(undef, size(SOLAR)[1]))
         vre_vre_stor = value.(EP[:vP_SOLAR]).data .*
-                       etainverter.(gen_VRE_STOR[(gen_VRE_STOR.solar .!= 0)])
+                       etainverter.(gen[SOLAR])
         if setup["ParameterScale"] == 1
             vre_vre_stor *= ModelScalingFactor
         end


### PR DESCRIPTION
## Description
This PR resolves the `UndefRefError: access to undefined reference` error encountered when running GenX with the recently released Julia v1.11. Specifically, Julia v1.11 introduced a new interface for vectors, and this PR updates the `getproperty` function for `Vector{GenXResources}` to ensure compatibility.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Related Tickets & Documents
This should fix the CI with Julia 1.11. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
It can be tested by running any of the examples with Julia 1.11. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
