### PR TITLE
Add add_similar_to_expression! for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 number of concurrent Gurobi uses is limited (#783).
 - Additional long-duration storage constraints to bound state of charge in 
 non-representative periods (#781).
+- New version of `add_similar_to_expression!` to support arrays of `Number`s. (#798)
 
 ### Changed
 - The `charge.csv` and `storage.csv` files now include only resources with 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.1-dev.16"
+version = "0.4.1-dev.17"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/model/core/operational_reserves.jl
+++ b/src/model/core/operational_reserves.jl
@@ -270,7 +270,6 @@ function operational_reserves_core!(EP::Model, inputs::Dict, setup::Dict)
     # N-1 contingency requirement is considered only if Unit Commitment is being modeled
     if UCommit >= 1 &&
        (inputs["pDynamic_Contingency"] >= 1 || inputs["pStatic_Contingency"] > 0)
-        # EP[:eRsvReq] = EP[:eRsvReq] + EP[:eContingencyReq]
         add_similar_to_expression!(EP[:eRsvReq], EP[:eContingencyReq])
     end
 

--- a/src/model/core/operational_reserves.jl
+++ b/src/model/core/operational_reserves.jl
@@ -270,7 +270,8 @@ function operational_reserves_core!(EP::Model, inputs::Dict, setup::Dict)
     # N-1 contingency requirement is considered only if Unit Commitment is being modeled
     if UCommit >= 1 &&
        (inputs["pDynamic_Contingency"] >= 1 || inputs["pStatic_Contingency"] > 0)
-        add_to_expression!(EP[:eRsvReq], EP[:eContingencyReq])
+        # EP[:eRsvReq] = EP[:eRsvReq] + EP[:eContingencyReq]
+        add_similar_to_expression!(EP[:eRsvReq], EP[:eContingencyReq])
     end
 
     ## Objective Function Expressions ##

--- a/src/model/expression_manipulation.jl
+++ b/src/model/expression_manipulation.jl
@@ -139,7 +139,8 @@ function add_similar_to_expression!(expr1::AbstractArray{GenericAffExpr{C, T}, d
 end
 
 # If the expressions are vectors of numbers, use the += operator
-function add_similar_to_expression!(arr1::AbstractArray{T, dims}, arr2::AbstractArray{T, dims}) where {T <: Number, dims}
+function add_similar_to_expression!(arr1::AbstractArray{T, dims},
+        arr2::AbstractArray{T, dims}) where {T <: Number, dims}
     for i in eachindex(arr1)
         arr1[i] += arr2[i]
     end

--- a/src/model/expression_manipulation.jl
+++ b/src/model/expression_manipulation.jl
@@ -138,6 +138,14 @@ function add_similar_to_expression!(expr1::AbstractArray{GenericAffExpr{C, T}, d
     return nothing
 end
 
+# If the expressions are vectors of numbers, use the += operator
+function add_similar_to_expression!(arr1::AbstractArray{T, dims}, arr2::AbstractArray{T, dims}) where {T <: Number, dims}
+    for i in eachindex(arr1)
+        arr1[i] += arr2[i]
+    end
+    return nothing
+end
+
 ###### ###### ###### ###### ###### ######
 # Element-wise addition of one term into an expression
 # Both arrays must have the same dimensions

--- a/test/expression_manipulation_test.jl
+++ b/test/expression_manipulation_test.jl
@@ -92,6 +92,12 @@ let
     GenX.add_similar_to_expression!(EP[:large_expr], EP[:large_const_expr])
     @test all(EP[:large_expr][:] .== 18.0)
 
+    # Test add_similar_to_expression! with AbstractArray{Number}
+    @expression(EP, eArr1[i = 1:100, j = 1:50], i*10.0+j*10.0)
+    @expression(EP, eArr2[i = 1:100, j = 1:50], -(i*10.0+j*10.0))
+    GenX.add_similar_to_expression!(EP[:eArr1], EP[:eArr2])
+    @test all(EP[:eArr1][:] .== 0.0)
+
     # Test add_similar_to_expression! returns an error if the dimensions don't match
     GenX.create_empty_expression!(EP, :small_expr, (2, 3))
     @test_throws ErrorException GenX.add_similar_to_expression!(EP[:large_expr],

--- a/test/expression_manipulation_test.jl
+++ b/test/expression_manipulation_test.jl
@@ -93,8 +93,8 @@ let
     @test all(EP[:large_expr][:] .== 18.0)
 
     # Test add_similar_to_expression! with AbstractArray{Number}
-    @expression(EP, eArr1[i = 1:100, j = 1:50], i*10.0+j*10.0)
-    @expression(EP, eArr2[i = 1:100, j = 1:50], -(i*10.0+j*10.0))
+    @expression(EP, eArr1[i = 1:100, j = 1:50], i * 10.0+j * 10.0)
+    @expression(EP, eArr2[i = 1:100, j = 1:50], -(i * 10.0 + j * 10.0))
     GenX.add_similar_to_expression!(EP[:eArr1], EP[:eArr2])
     @test all(EP[:eArr1][:] .== 0.0)
 


### PR DESCRIPTION
## Description

Addresses #778 by adding a new version of `add_similar_to_expression!` in `expression_manipulation.jl`, which handles expressions that are `Arrays` rather than `GenericAffExpr`. This implementation performs an elementwise sum of the two arrays, similar to the behavior of the `+` operator in `EP[:expr1] = EP[:expr1] + EP[:expr2]` when `expr*` are vectors.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Related Tickets & Documents
#778.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
As the Issue description suggests, this can be replicated with the `5_three_zones_w_piecewise_fuel` example case by entering 2000 for the `Static_Contingency_MW`. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
