### PR TITLE
Settings flag for new LDS constraints activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ number of concurrent Gurobi uses is limited (#783).
 - Additional long-duration storage constraints to bound state of charge in 
 non-representative periods (#781).
 - New version of `add_similar_to_expression!` to support arrays of `Number`s. (#798)
+- New settings flag `LDSAdditionalConstraints` to provide flexibility in activating new long-duration storage constraints (#781). Can be set in the GenX settings file (PR #801).
 
 ### Changed
 - The `charge.csv` and `storage.csv` files now include only resources with 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ number of concurrent Gurobi uses is limited (#783).
 - Additional long-duration storage constraints to bound state of charge in 
 non-representative periods (#781).
 - New version of `add_similar_to_expression!` to support arrays of `Number`s. (#798)
-- New settings flag `LDSAdditionalConstraints` to provide flexibility in activating new long-duration storage constraints (#781). Can be set in the GenX settings file (PR #801).
+- New settings flag `LDSAdditionalConstraints` to provide flexibility in 
+activating new long-duration storage constraints (#781). Can be set in the GenX 
+settings file (PR #801).
 
 ### Changed
 - The `charge.csv` and `storage.csv` files now include only resources with 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.1-dev.19"
+version = "0.4.1-dev.20"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/Tutorials/Tutorial_4_model_generation.md
+++ b/docs/src/Tutorials/Tutorial_4_model_generation.md
@@ -474,7 +474,7 @@ end
 
 # Model constraints, variables, expression related to reservoir hydropower resources with long duration storage
 if inputs["REP_PERIOD"] > 1 && !isempty(inputs["STOR_HYDRO_LONG_DURATION"])
-    GenX.hydro_inter_period_linkage!(EP, inputs)
+    GenX.hydro_inter_period_linkage!(EP, inputs, setup)
 end
 
 # Model constraints, variables, expression related to demand flexibility resources

--- a/docs/src/User_Guide/model_configuration.md
+++ b/docs/src/User_Guide/model_configuration.md
@@ -31,6 +31,9 @@ The following tables summarize the model settings parameters and their default/p
 |StorageVirtualDischarge | Flag to enable contributions that a storage device makes to the capacity reserve margin without generating power.|
 ||1 = activate the virtual discharge of storage resources.|
 ||0 = do not activate the virtual discharge of storage resources.|
+|LDSAdditionalConstraints | Flag to activate additional constraints for long duration storage resources to prevent violation of SoC limits in non-representative periods.|
+||1 = activate additional constraints.|
+||0 = do not activate additional constraints.|
 |HourlyMatching| Constraint to match generation from clean sources with hourly consumption.|
 ||1 = Constraint is active.|
 ||0 = Constraint is not active.|

--- a/example_systems/3_three_zones_w_co2_capture/resources/Storage.csv
+++ b/example_systems/3_three_zones_w_co2_capture/resources/Storage.csv
@@ -1,4 +1,4 @@
-Resource,Zone,Model,New_Build,Can_Retire,Existing_Cap_MW,Existing_Cap_MWh,Max_Cap_MW,Max_Cap_MWh,Min_Cap_MW,Min_Cap_MWh,Inv_Cost_per_MWyr,Inv_Cost_per_MWhyr,Fixed_OM_Cost_per_MWyr,Fixed_OM_Cost_per_MWhyr,Var_OM_Cost_per_MWh,Var_OM_Cost_per_MWh_In,Self_Disch,Eff_Up,Eff_Down,Min_Duration,Max_Duration,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
-MA_battery,1,1,1,0,0,0,-1,-1,0,0,19584,22494,4895,5622,0.15,0.15,0,0.92,0.92,1,10,0,0,0,0,MA,0
-CT_battery,2,1,1,0,0,0,-1,-1,0,0,19584,22494,4895,5622,0.15,0.15,0,0.92,0.92,1,10,0,0,0,0,CT,0
-ME_battery,3,1,1,0,0,0,-1,-1,0,0,19584,22494,4895,5622,0.15,0.15,0,0.92,0.92,1,10,0,0,0,0,ME,0
+Resource,Zone,LDS,Model,New_Build,Can_Retire,Existing_Cap_MW,Existing_Cap_MWh,Max_Cap_MW,Max_Cap_MWh,Min_Cap_MW,Min_Cap_MWh,Inv_Cost_per_MWyr,Inv_Cost_per_MWhyr,Fixed_OM_Cost_per_MWyr,Fixed_OM_Cost_per_MWhyr,Var_OM_Cost_per_MWh,Var_OM_Cost_per_MWh_In,Self_Disch,Eff_Up,Eff_Down,Min_Duration,Max_Duration,Reg_Max,Rsv_Max,Reg_Cost,Rsv_Cost,region,cluster
+MA_battery,1,0,1,1,0,0,0,-1,-1,0,0,19584,22494,4895,5622,0.15,0.15,0,0.92,0.92,1,10,0,0,0,0,MA,0
+CT_battery,2,0,1,1,0,0,0,-1,-1,0,0,19584,22494,4895,5622,0.15,0.15,0,0.92,0.92,1,10,0,0,0,0,CT,0
+ME_battery,3,0,1,1,0,0,0,-1,-1,0,0,19584,22494,4895,5622,0.15,0.15,0,0.92,0.92,1,10,0,0,0,0,ME,0

--- a/example_systems/3_three_zones_w_co2_capture/settings/genx_settings.yml
+++ b/example_systems/3_three_zones_w_co2_capture/settings/genx_settings.yml
@@ -10,3 +10,4 @@ ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered) 
+LDSAdditionalConstraints: 1 # Activate additional constraints to prevent violation of SoC limits in non-representative periods; 0 = not active; 1 = active

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -8,7 +8,7 @@ function default_settings()
         "CapacityReserveMargin" => 0,
         "CO2Cap" => 0,
         "StorageLosses" => 1,
-        "LDSAdditionalConstraints" => 0,
+        "LDSAdditionalConstraints" => 1,
         "VirtualChargeDischargeCost" => 1,  # $/MWh
         "MinCapReq" => 0,
         "MaxCapReq" => 0,

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -8,6 +8,7 @@ function default_settings()
         "CapacityReserveMargin" => 0,
         "CO2Cap" => 0,
         "StorageLosses" => 1,
+        "LDSAdditionalConstraints" => 0,
         "VirtualChargeDischargeCost" => 1,  # $/MWh
         "MinCapReq" => 0,
         "MaxCapReq" => 0,

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -171,7 +171,7 @@ function generate_model(setup::Dict, inputs::Dict, OPTIMIZER::MOI.OptimizerWithA
 
     # Model constraints, variables, expression related to reservoir hydropower resources with long duration storage
     if inputs["REP_PERIOD"] > 1 && !isempty(inputs["STOR_HYDRO_LONG_DURATION"])
-        hydro_inter_period_linkage!(EP, inputs)
+        hydro_inter_period_linkage!(EP, inputs, setup)
     end
 
     # Model constraints, variables, expression related to demand flexibility resources

--- a/src/model/resources/storage/long_duration_storage.jl
+++ b/src/model/resources/storage/long_duration_storage.jl
@@ -133,11 +133,14 @@ function long_duration_storage!(EP::Model, inputs::Dict, setup::Dict)
         @variable(EP, vCAPRES_dsoc[y in STOR_LONG_DURATION, w = 1:REP_PERIOD])
     end
 
-    # Maximum positive storage inventory change within subperiod
-	@variable(EP, vdSOC_maxPos[y in STOR_LONG_DURATION, w=1:REP_PERIOD] >= 0)
+    # Additional constraints to prevent violation of SoC limits in non-representative periods
+    if setup["LDSAdditionalConstraints"] == 1
+        # Maximum positive storage inventory change within subperiod
+        @variable(EP, vdSOC_maxPos[y in STOR_LONG_DURATION, w=1:REP_PERIOD] >= 0)
 
-	# Maximum negative storage inventory change within subperiod
-	@variable(EP, vdSOC_maxNeg[y in STOR_LONG_DURATION, w=1:REP_PERIOD] <= 0)
+        # Maximum negative storage inventory change within subperiod
+        @variable(EP, vdSOC_maxNeg[y in STOR_LONG_DURATION, w=1:REP_PERIOD] <= 0)
+    end
 
     ### Constraints ###
 
@@ -225,23 +228,26 @@ function long_duration_storage!(EP::Model, inputs::Dict, setup::Dict)
             vSOCw[y, r]>=vCAPRES_socw[y, r])
     end
 
-    # Extract maximum storage level variation (positive) within subperiod
-	@constraint(EP, cMaxSoCVarPos[y in STOR_LONG_DURATION, w=1:REP_PERIOD, t=2:hours_per_subperiod],
+    if setup["LDSAdditionalConstraints"] == 1
+        # Extract maximum storage level variation (positive) within subperiod
+        @constraint(EP, cMaxSoCVarPos[y in STOR_LONG_DURATION, w=1:REP_PERIOD, t=2:hours_per_subperiod],
                     vdSOC_maxPos[y,w] >= EP[:vS][y,hours_per_subperiod*(w-1)+t] - EP[:vS][y,hours_per_subperiod*(w-1)+1])
 
-    # Extract maximum storage level variation (negative) within subperiod
-    @constraint(EP, cMaxSoCVarNeg[y in STOR_LONG_DURATION, w=1:REP_PERIOD, t=2:hours_per_subperiod],
+        # Extract maximum storage level variation (negative) within subperiod
+        @constraint(EP, cMaxSoCVarNeg[y in STOR_LONG_DURATION, w=1:REP_PERIOD, t=2:hours_per_subperiod],
                     vdSOC_maxNeg[y,w] <= EP[:vS][y,hours_per_subperiod*(w-1)+t] - EP[:vS][y,hours_per_subperiod*(w-1)+1])
 
-    # Max storage content within each modeled period cannot exceed installed energy capacity
-    @constraint(EP, cSoCLongDurationStorageMaxInt[y in STOR_LONG_DURATION, r in MODELED_PERIODS_INDEX],
-            (1-self_discharge(gen[y]))*vSOCw[y,r]-(1/efficiency_down(gen[y])*EP[:vP][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
-            +(efficiency_up(gen[y])*EP[:vCHARGE][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
-            +vdSOC_maxPos[y,dfPeriodMap[r,:Rep_Period_Index]] <= EP[:eTotalCapEnergy][y])
+        # Max storage content within each modeled period cannot exceed installed energy capacity
+        @constraint(EP, cSoCLongDurationStorageMaxInt[y in STOR_LONG_DURATION, r in MODELED_PERIODS_INDEX],
+                (1-self_discharge(gen[y]))*vSOCw[y,r]-(1/efficiency_down(gen[y])*EP[:vP][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
+                +(efficiency_up(gen[y])*EP[:vCHARGE][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
+                +vdSOC_maxPos[y,dfPeriodMap[r,:Rep_Period_Index]] <= EP[:eTotalCapEnergy][y])
 
-    # Min storage content within each modeled period cannot be negative
-    @constraint(EP, cSoCLongDurationStorageMinInt[y in STOR_LONG_DURATION, r in MODELED_PERIODS_INDEX],
-            (1-self_discharge(gen[y]))*vSOCw[y,r]-(1/efficiency_down(gen[y])*EP[:vP][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
-            +(efficiency_up(gen[y])*EP[:vCHARGE][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
-            +vdSOC_maxNeg[y,dfPeriodMap[r,:Rep_Period_Index]] >= 0)
+        # Min storage content within each modeled period cannot be negative
+        @constraint(EP, cSoCLongDurationStorageMinInt[y in STOR_LONG_DURATION, r in MODELED_PERIODS_INDEX],
+                (1-self_discharge(gen[y]))*vSOCw[y,r]-(1/efficiency_down(gen[y])*EP[:vP][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
+                +(efficiency_up(gen[y])*EP[:vCHARGE][y,hours_per_subperiod*(dfPeriodMap[r,:Rep_Period_Index]-1)+1])
+                +vdSOC_maxNeg[y,dfPeriodMap[r,:Rep_Period_Index]] >= 0)
+    end
 end
+


### PR DESCRIPTION
## Description

This PR introduces a new settings flag to provide flexibility in activating new long-duration storage constraints (PR #781).

## What type of PR is this? (check all applicable)

- [x] Feature

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

Using the "3_three_zones_w_co2_capture" example case and enabling LDS on storage resources.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
