### PR TITLE
Add `eTotalCMaxCapSlack` to `cUnmetPolicyPenalty` in `write_costs.jl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ the charging capacity of the storage component in VRE_STOR (#770).
 with Julia v1.11 (#785).
 - Fixed cost calculation in `write_costs.jl` when no resources are present in 
 a zone. (#796)
+- Added `eTotalCMaxCapSlack` to calculation of `cUnmetPolicyPenalty` in 
+`write_costs.jl` (#806).
 
 ## [0.4.1] - 2024-08-20
 

--- a/src/write_outputs/write_costs.jl
+++ b/src/write_outputs/write_costs.jl
@@ -127,6 +127,10 @@ function write_costs(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
         dfCost[9, 2] += value(EP[:eTotalCMinCapSlack])
     end
 
+    if haskey(inputs, "MaxCapPriceCap")
+        dfCost[9, 2] += value(EP[:eTotalCMaxCapSlack])
+    end
+
     if haskey(inputs, "H2DemandPriceCap")
         dfCost[9, 2] += value(EP[:eTotalCH2DemandSlack])
     end


### PR DESCRIPTION
## Description

This PR addresses #804 by adding the expression `eTotalCMaxCapSlack` to the `cUnmetPolicyPenalty` column in the `costs.csv` file.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Related Tickets & Documents
Fixes #804.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

Using the `example_systems/4_three_zones_w_policies_slack` example. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
